### PR TITLE
Implement postgreSQL module

### DIFF
--- a/modules/debian/cloudinit.tf
+++ b/modules/debian/cloudinit.tf
@@ -50,7 +50,8 @@ data "cloudinit_config" "user_data" {
             cloud_final_modules = [
               "package_update_upgrade_install",
               "scripts_user", # required for runcmd
-              "power_state_change"
+              "power_state_change",
+              "write-files-deferred",
             ]
             hostname         = var.name
             manage_etc_hosts = true

--- a/modules/debian/config.tf
+++ b/modules/debian/config.tf
@@ -128,6 +128,7 @@ locals {
       path        = file.path
       owner       = format("%s:%s", file.owner, file.group)
       permissions = length(file.mode) < 4 ? "0${file.mode}" : file.mode
+      defer       = true # ensure users, packages are created before writing extra files 
     } if file.enabled == true && !startswith(file.content, "https://") && strcontains(file.tags, lookup(file, "tags", "cloud-init"))
   ]
   repositories = merge(

--- a/modules/nomad-postgres/README.md
+++ b/modules/nomad-postgres/README.md
@@ -1,0 +1,30 @@
+# Terraform module for running PostgreSQL on Nomad
+
+This module only works with Debian currently. This module assumes the `postgresql` package is installed in the host
+Debian system.
+
+## Usage
+
+```terraform
+module "nomad_postgres" {
+  source = "github.com/narwhl/blueprint//modules/nomad-postgres"
+  datacenter_name = "dc1"
+  pgbackrest_s3_config = {
+    endpoint   = "https://${data.cloudflare_accounts.cf_account.accounts[0].id}.r2.cloudflarestorage.com"
+    bucket     = cloudflare_r2_bucket.pgbackrest.name
+    access_key = "<access_key>"
+    secret_key = "<secret_key>"
+    region     = "us-east-1"
+  }
+  restore_backup = true
+}
+```
+
+## Configuration
+
+`datacenter_name`: The name of the Nomad datacenter to use.
+
+`pgbackrest_s3_config`: The configuration for pgbackrest to use.
+
+`restore_backup`: Whether to restore a backup. Defaults to `false`. If true, the restore job will be run instead of the
+initialization job to restore the database.

--- a/modules/nomad-postgres/main.tf
+++ b/modules/nomad-postgres/main.tf
@@ -1,0 +1,50 @@
+locals {
+  pgbackrest_conf = templatefile(
+    "${path.module}/templates/pgbackrest.conf.tftpl",
+    {
+      s3_endpoint       = var.pgbackrest_s3_config.endpoint
+      s3_bucket         = var.pgbackrest_s3_config.bucket
+      s3_access_key     = var.pgbackrest_s3_config.access_key
+      s3_secret_key     = var.pgbackrest_s3_config.secret_key
+      s3_region         = var.pgbackrest_s3_config.region
+      pgbackrest_stanza = var.pgbackrest_stanza
+    }
+  )
+}
+
+resource "nomad_job" "postgres" {
+  jobspec = templatefile(
+    "${path.module}/templates/postgres.nomad.hcl.tftpl",
+    {
+      job_name          = var.postgres_job_name
+      datacenter_name   = var.datacenter_name
+      pgbackrest_conf   = local.pgbackrest_conf
+      pgbackrest_stanza = var.pgbackrest_stanza
+    }
+  )
+}
+
+resource "nomad_job" "pgbackrest" {
+  jobspec = templatefile(
+    "${path.module}/templates/pgbackrest.nomad.hcl.tftpl",
+    {
+      job_name          = var.pgbackrest_job_name
+      datacenter_name   = var.datacenter_name
+      pgbackrest_conf   = local.pgbackrest_conf
+      pgbackrest_stanza = var.pgbackrest_stanza
+      backup_schedule   = var.backup_schedule
+    }
+  )
+}
+
+resource "nomad_job" "pgbackrest_init" {
+  jobspec = templatefile(
+    "${path.module}/templates/pgbackrest-init.nomad.hcl.tftpl",
+    {
+      job_name          = var.pgbackrest_init_job_name
+      datacenter_name   = var.datacenter_name
+      pgbackrest_conf   = local.pgbackrest_conf
+      pgbackrest_stanza = var.pgbackrest_stanza
+    }
+  )
+}

--- a/modules/nomad-postgres/main.tf
+++ b/modules/nomad-postgres/main.tf
@@ -38,10 +38,24 @@ resource "nomad_job" "pgbackrest" {
 }
 
 resource "nomad_job" "pgbackrest_init" {
+  count = var.restore_backup ? 0 : 1
   jobspec = templatefile(
     "${path.module}/templates/pgbackrest-init.nomad.hcl.tftpl",
     {
       job_name          = var.pgbackrest_init_job_name
+      datacenter_name   = var.datacenter_name
+      pgbackrest_conf   = local.pgbackrest_conf
+      pgbackrest_stanza = var.pgbackrest_stanza
+    }
+  )
+}
+
+resource "nomad_job" "pgbackrest_restore" {
+  count = var.restore_backup ? 1 : 0
+  jobspec = templatefile(
+    "${path.module}/templates/pgbackrest-restore.nomad.hcl.tftpl",
+    {
+      job_name          = var.pgbackrest_restore_job_name
       datacenter_name   = var.datacenter_name
       pgbackrest_conf   = local.pgbackrest_conf
       pgbackrest_stanza = var.pgbackrest_stanza

--- a/modules/nomad-postgres/main.tf
+++ b/modules/nomad-postgres/main.tf
@@ -16,10 +16,13 @@ resource "nomad_job" "postgres" {
   jobspec = templatefile(
     "${path.module}/templates/postgres.nomad.hcl.tftpl",
     {
-      job_name          = var.postgres_job_name
-      datacenter_name   = var.datacenter_name
-      pgbackrest_conf   = local.pgbackrest_conf
-      pgbackrest_stanza = var.pgbackrest_stanza
+      job_name                         = var.postgres_job_name
+      datacenter_name                  = var.datacenter_name
+      pgbackrest_conf                  = local.pgbackrest_conf
+      pgbackrest_stanza                = var.pgbackrest_stanza
+      postgres_socket_host_volume_name = var.postgres_host_volumes_name.socket
+      postgres_data_host_volume_name   = var.postgres_host_volumes_name.data
+      postgres_log_host_volume_name    = var.postgres_host_volumes_name.log
     }
   )
 }
@@ -28,11 +31,14 @@ resource "nomad_job" "pgbackrest" {
   jobspec = templatefile(
     "${path.module}/templates/pgbackrest.nomad.hcl.tftpl",
     {
-      job_name          = var.pgbackrest_job_name
-      datacenter_name   = var.datacenter_name
-      pgbackrest_conf   = local.pgbackrest_conf
-      pgbackrest_stanza = var.pgbackrest_stanza
-      backup_schedule   = var.backup_schedule
+      job_name                         = var.pgbackrest_job_name
+      datacenter_name                  = var.datacenter_name
+      pgbackrest_conf                  = local.pgbackrest_conf
+      pgbackrest_stanza                = var.pgbackrest_stanza
+      backup_schedule                  = var.backup_schedule
+      postgres_socket_host_volume_name = var.postgres_host_volumes_name.socket
+      postgres_data_host_volume_name   = var.postgres_host_volumes_name.data
+      postgres_log_host_volume_name    = var.postgres_host_volumes_name.log
     }
   )
 }
@@ -42,10 +48,13 @@ resource "nomad_job" "pgbackrest_init" {
   jobspec = templatefile(
     "${path.module}/templates/pgbackrest-init.nomad.hcl.tftpl",
     {
-      job_name          = var.pgbackrest_init_job_name
-      datacenter_name   = var.datacenter_name
-      pgbackrest_conf   = local.pgbackrest_conf
-      pgbackrest_stanza = var.pgbackrest_stanza
+      job_name                         = var.pgbackrest_init_job_name
+      datacenter_name                  = var.datacenter_name
+      pgbackrest_conf                  = local.pgbackrest_conf
+      pgbackrest_stanza                = var.pgbackrest_stanza
+      postgres_socket_host_volume_name = var.postgres_host_volumes_name.socket
+      postgres_data_host_volume_name   = var.postgres_host_volumes_name.data
+      postgres_log_host_volume_name    = var.postgres_host_volumes_name.log
     }
   )
 }
@@ -55,10 +64,13 @@ resource "nomad_job" "pgbackrest_restore" {
   jobspec = templatefile(
     "${path.module}/templates/pgbackrest-restore.nomad.hcl.tftpl",
     {
-      job_name          = var.pgbackrest_restore_job_name
-      datacenter_name   = var.datacenter_name
-      pgbackrest_conf   = local.pgbackrest_conf
-      pgbackrest_stanza = var.pgbackrest_stanza
+      job_name                         = var.pgbackrest_restore_job_name
+      datacenter_name                  = var.datacenter_name
+      pgbackrest_conf                  = local.pgbackrest_conf
+      pgbackrest_stanza                = var.pgbackrest_stanza
+      postgres_socket_host_volume_name = var.postgres_host_volumes_name.socket
+      postgres_data_host_volume_name   = var.postgres_host_volumes_name.data
+      postgres_log_host_volume_name    = var.postgres_host_volumes_name.log
     }
   )
 }

--- a/modules/nomad-postgres/templates/pgbackrest-init.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest-init.nomad.hcl.tftpl
@@ -1,0 +1,56 @@
+job "${job_name}" {
+  datacenters = ["*"]
+  type        = "batch"
+
+  group "${job_name}" {
+    volume "postgres-socket" {
+      type = "host"
+      source = "postgres-socket"
+    }
+    volume "postgres-data" {
+      type = "host"
+      source = "postgres-data"
+    }
+    volume "postgres-log" {
+      type = "host"
+      source = "postgres-log"
+    }
+    task "${job_name}" {
+      driver = "exec"
+
+      volume_mount {
+        volume      = "postgres-socket"
+        destination = "/var/run/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-data"
+        destination = "/var/lib/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-log"
+        destination = "/var/log/postgresql"
+      }
+
+      config {
+        command = "/usr/bin/pgbackrest"
+        args    = [
+          "--config", "$${NOMAD_TASK_DIR}/pgbackrest.conf",
+          "--stanza=${pgbackrest_stanza}",
+          "stanza-create"
+        ]
+      }
+
+      user = "postgres"
+
+      template {
+        data        = <<EOH
+${pgbackrest_conf}
+EOH
+        destination = "$${NOMAD_TASK_DIR}/pgbackrest.conf"
+      }
+    }
+  }
+}
+

--- a/modules/nomad-postgres/templates/pgbackrest-init.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest-init.nomad.hcl.tftpl
@@ -4,16 +4,16 @@ job "${job_name}" {
 
   group "${job_name}" {
     volume "postgres-socket" {
-      type = "host"
-      source = "postgres-socket"
+      type   = "host"
+      source = "${postgres_socket_host_volume_name}"
     }
     volume "postgres-data" {
-      type = "host"
-      source = "postgres-data"
+      type   = "host"
+      source = "${postgres_data_host_volume_name}"
     }
     volume "postgres-log" {
-      type = "host"
-      source = "postgres-log"
+      type   = "host"
+      source = "${postgres_log_host_volume_name}"
     }
     task "${job_name}" {
       driver = "exec"

--- a/modules/nomad-postgres/templates/pgbackrest-restore.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest-restore.nomad.hcl.tftpl
@@ -1,0 +1,57 @@
+job "${job_name}" {
+  datacenters = ["*"]
+  type        = "batch"
+
+  group "${job_name}" {
+    volume "postgres-socket" {
+      type = "host"
+      source = "postgres-socket"
+    }
+    volume "postgres-data" {
+      type = "host"
+      source = "postgres-data"
+    }
+    volume "postgres-log" {
+      type = "host"
+      source = "postgres-log"
+    }
+    task "${job_name}" {
+      driver = "exec"
+
+      volume_mount {
+        volume      = "postgres-socket"
+        destination = "/var/run/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-data"
+        destination = "/var/lib/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-log"
+        destination = "/var/log/postgresql"
+      }
+
+      config {
+        command = "/usr/bin/pgbackrest"
+        args    = [
+          "--config", "$${NOMAD_TASK_DIR}/pgbackrest.conf",
+          "--stanza=${pgbackrest_stanza}",
+          "--delta",
+          "restore"
+        ]
+      }
+
+      user = "postgres"
+
+      template {
+        data        = <<EOH
+${pgbackrest_conf}
+EOH
+        destination = "$${NOMAD_TASK_DIR}/pgbackrest.conf"
+      }
+    }
+  }
+}
+

--- a/modules/nomad-postgres/templates/pgbackrest-restore.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest-restore.nomad.hcl.tftpl
@@ -4,16 +4,16 @@ job "${job_name}" {
 
   group "${job_name}" {
     volume "postgres-socket" {
-      type = "host"
-      source = "postgres-socket"
+      type   = "host"
+      source = "${postgres_socket_host_volume_name}"
     }
     volume "postgres-data" {
-      type = "host"
-      source = "postgres-data"
+      type   = "host"
+      source = "${postgres_data_host_volume_name}"
     }
     volume "postgres-log" {
-      type = "host"
-      source = "postgres-log"
+      type   = "host"
+      source = "${postgres_log_host_volume_name}"
     }
     task "${job_name}" {
       driver = "exec"

--- a/modules/nomad-postgres/templates/pgbackrest.conf
+++ b/modules/nomad-postgres/templates/pgbackrest.conf
@@ -1,0 +1,15 @@
+[global]
+repo1-type=s3
+repo1-s3-endpoint=https://c814d4c5591b582edf31951b0bd09497.r2.cloudflarestorage.com
+repo1-s3-bucket=pgbackup
+repo1-s3-key=77beef5a54f85ae8c1f177351fe6d7f6
+repo1-s3-key-secret=0707aef33e982d235683f95d6b1bace7ec146b2851ac5885fc8d282a87b4efaa
+repo1-s3-region=us-east-1
+repo1-path=/var/lib/pgbackrest
+
+repo1-retention-full=1
+start-fast=y
+archive-async=y
+
+[db-primary]
+pg1-path=/var/lib/postgresql/15/main

--- a/modules/nomad-postgres/templates/pgbackrest.conf.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest.conf.tftpl
@@ -1,0 +1,15 @@
+[global]
+repo1-type=s3
+repo1-s3-endpoint=${s3_endpoint}
+repo1-s3-bucket=${s3_bucket}
+repo1-s3-key=${s3_access_key}
+repo1-s3-key-secret=${s3_secret_key}
+repo1-s3-region=${s3_region}
+repo1-path=/var/lib/pgbackrest
+
+repo1-retention-full=1
+start-fast=y
+archive-async=y
+
+[${pgbackrest_stanza}]
+pg1-path=/var/lib/postgresql/15/main

--- a/modules/nomad-postgres/templates/pgbackrest.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest.nomad.hcl.tftpl
@@ -9,16 +9,16 @@ job "${job_name}" {
 
   group "${job_name}" {
     volume "postgres-socket" {
-      type = "host"
-      source = "postgres-socket"
+      type   = "host"
+      source = "${postgres_socket_host_volume_name}"
     }
     volume "postgres-data" {
-      type = "host"
-      source = "postgres-data"
+      type   = "host"
+      source = "${postgres_data_host_volume_name}"
     }
     volume "postgres-log" {
-      type = "host"
-      source = "postgres-log"
+      type   = "host"
+      source = "${postgres_log_host_volume_name}"
     }
     task "${job_name}" {
       driver = "exec"

--- a/modules/nomad-postgres/templates/pgbackrest.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/pgbackrest.nomad.hcl.tftpl
@@ -1,0 +1,62 @@
+job "${job_name}" {
+  datacenters = ["*"]
+  type        = "batch"
+
+  periodic {
+    cron             = "${backup_schedule}"
+    prohibit_overlap = true
+  }
+
+  group "${job_name}" {
+    volume "postgres-socket" {
+      type = "host"
+      source = "postgres-socket"
+    }
+    volume "postgres-data" {
+      type = "host"
+      source = "postgres-data"
+    }
+    volume "postgres-log" {
+      type = "host"
+      source = "postgres-log"
+    }
+    task "${job_name}" {
+      driver = "exec"
+
+      volume_mount {
+        volume      = "postgres-socket"
+        destination = "/var/run/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-data"
+        destination = "/var/lib/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-log"
+        destination = "/var/log/postgresql"
+      }
+
+      config {
+        command = "/usr/bin/pgbackrest"
+        args    = [
+          "--config", "$${NOMAD_TASK_DIR}/pgbackrest.conf",
+          "--stanza=${pgbackrest_stanza}",
+          "--type=full",
+          "backup"
+        ]
+      }
+
+      user = "postgres"
+
+      template {
+        data        = <<EOH
+${pgbackrest_conf}
+EOH
+        destination = "$${NOMAD_TASK_DIR}/pgbackrest.conf"
+      }
+    }
+  }
+}
+

--- a/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
@@ -10,16 +10,16 @@ job "${job_name}" {
       }
     }
     volume "postgres-socket" {
-      type = "host"
-      source = "postgres-socket"
+      type   = "host"
+      source = "${postgres_socket_host_volume_name}"
     }
     volume "postgres-data" {
-      type = "host"
-      source = "postgres-data"
+      type   = "host"
+      source = "${postgres_data_host_volume_name}"
     }
     volume "postgres-log" {
-      type = "host"
-      source = "postgres-log"
+      type   = "host"
+      source = "${postgres_log_host_volume_name}"
     }
     task "${job_name}" {
       driver = "exec"

--- a/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
@@ -3,6 +3,12 @@ job "${job_name}" {
   type        = "service"
 
   group "${job_name}" {
+    network {
+      mode = "bridge"
+      port "postgres" {
+        static = 5432
+      }
+    }
     volume "postgres-socket" {
       type = "host"
       source = "postgres-socket"
@@ -56,6 +62,30 @@ archive_command = 'pgbackrest --stanza=${pgbackrest_stanza} --config /local/pgba
 EOH
         # exec driver can render templates outside of the NOMAD_TASK_DIR
         destination = "/etc/postgresql/15/main/conf.d/50-pgbackrest.conf"
+      }
+      template {
+        data        = "listen_addresses = '*'"
+        destination = "/etc/postgresql/15/main/conf.d/50-listen-addresses.conf"
+      }
+      template {
+        data        = <<EOH
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+# Allow connections outside container
+host    all             all             all                     scram-sha-256
+EOH
+        destination = "/etc/postgresql/15/main/pg_hba.conf"
       }
     }
   }

--- a/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
@@ -1,0 +1,62 @@
+job "${job_name}" {
+  datacenters = ["${datacenter_name}"]
+  type        = "service"
+
+  group "${job_name}" {
+    volume "postgres-socket" {
+      type = "host"
+      source = "postgres-socket"
+    }
+    volume "postgres-data" {
+      type = "host"
+      source = "postgres-data"
+    }
+    volume "postgres-log" {
+      type = "host"
+      source = "postgres-log"
+    }
+    task "${job_name}" {
+      driver = "exec"
+
+      volume_mount {
+        volume      = "postgres-socket"
+        destination = "/var/run/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-data"
+        destination = "/var/lib/postgresql"
+      }
+
+      volume_mount {
+        volume      = "postgres-log"
+        destination = "/var/log/postgresql"
+      }
+
+      config {
+        command = "/usr/bin/pg_ctlcluster"
+        args    = [
+          "15", "main", "start", "--foreground"
+        ]
+      }
+
+      user = "postgres"
+
+      template {
+        data        = <<EOH
+${pgbackrest_conf}
+EOH
+        destination = "$${NOMAD_TASK_DIR}/pgbackrest.conf"
+      }
+
+      template {
+        data        = <<EOH
+archive_mode = on
+archive_command = 'pgbackrest --stanza=${pgbackrest_stanza} --config /local/pgbackrest.conf archive-push %p'
+EOH
+        # exec driver can render templates outside of the NOMAD_TASK_DIR
+        destination = "/etc/postgresql/15/main/conf.d/50-pgbackrest.conf"
+      }
+    }
+  }
+}

--- a/modules/nomad-postgres/variables.tf
+++ b/modules/nomad-postgres/variables.tf
@@ -19,6 +19,11 @@ variable "pgbackrest_init_job_name" {
   default = "pgbackrest-init"
 }
 
+variable "pgbackrest_restore_job_name" {
+  type    = string
+  default = "pgbackrest-restore"
+}
+
 variable "datacenter_name" {
   type        = string
   description = "Name of the datacenter"
@@ -46,5 +51,10 @@ variable "pgbackrest_stanza" {
   description = "The pgBackRest stanza to use"
 }
 
+variable "restore_backup" {
+  type        = bool
+  default     = false
+  description = "Whether to restore backup from specified S3 bucket"
+}
 
 

--- a/modules/nomad-postgres/variables.tf
+++ b/modules/nomad-postgres/variables.tf
@@ -51,6 +51,20 @@ variable "pgbackrest_stanza" {
   description = "The pgBackRest stanza to use"
 }
 
+variable "postgres_host_volumes_name" {
+  type = object({
+    data   = string
+    socket = string
+    log    = string
+  })
+  default = {
+    data   = "postgres-data"
+    socket = "postgres-socket"
+    log    = "postgres-log"
+  }
+  description = "The name of the PostgreSQL host volumes"
+}
+
 variable "restore_backup" {
   type        = bool
   default     = false

--- a/modules/nomad-postgres/variables.tf
+++ b/modules/nomad-postgres/variables.tf
@@ -1,0 +1,50 @@
+variable "postgres_job_name" {
+  type    = string
+  default = "postgres"
+}
+
+variable "backup_schedule" {
+  type        = string
+  default     = "@weekly"
+  description = "Backup schedule in cron syntax"
+}
+
+variable "pgbackrest_job_name" {
+  type    = string
+  default = "pgbackrest"
+}
+
+variable "pgbackrest_init_job_name" {
+  type    = string
+  default = "pgbackrest-init"
+}
+
+variable "datacenter_name" {
+  type        = string
+  description = "Name of the datacenter"
+  validation {
+    condition     = length(var.datacenter_name) > 0
+    error_message = "Datacenter name cannot be empty"
+  }
+}
+
+variable "pgbackrest_s3_config" {
+  type = object({
+    endpoint   = string
+    bucket     = string
+    access_key = string
+    secret_key = string
+    region     = string
+  })
+  sensitive   = true
+  description = "The pgBackRest repo S3 configuration"
+}
+
+variable "pgbackrest_stanza" {
+  type        = string
+  default     = "db-primary"
+  description = "The pgBackRest stanza to use"
+}
+
+
+

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -1,0 +1,48 @@
+# Terraform module for running Nomad on Flatcar/ Debian
+
+## Usage
+
+Include output `manifest` in `substrates` of `debian` or `flatcar` module.
+
+```terraform
+module "nomad" {
+    source = "github.com/narwhl/blueprint//modules/nomad"
+    datacenter_name = "dc1"
+    role            = "server"
+}
+
+# Alternatively, you may use Flatcar module
+module "debian" {
+  source = "github.com/narwhl/blueprint//modules/debian"
+  name   = "debian-vm"
+  substrates = [
+    module.nomad.manifest,
+    ...
+  ]
+  ...
+}
+```
+
+### Configuration
+
+`supplychain`: Address pointing to upstream dependency JSON metadata file. This should leave as default unless package
+versions need to be customized. Defaults to `https://artifact.narwhl.dev/upstream/current.json`.
+
+`data_dir`: The directory to store Nomad data. Defaults to `/opt/nomad`.
+
+`datacenter_name`: The name of the Nomad datacenter to use.
+
+`log_level`: The log level to use. Defaults to `INFO`.
+
+`role`: The role of the Nomad node to run, can be `client` or `server`. Defaults to `server`.
+
+`bootstrap_expect`: Number of nomad instance connection expected to form the cluster. Must be an odd integer.
+Defaults to `1`.
+
+`gossip_key`: The gossip encryption key. Gossip encryption is not enforced when leaving this empty.
+
+`tls`: The TLS certificate configuration. TLS is not enforced when leaving this empty.
+
+`host_volume`: A map of host volume configurations. The key is the host volume name and the value is an object with
+the `path` and `read_only` fields. The `path` field is the path on the host where the volume is mounted and the
+`read_only` field is a boolean indicating whether the volume is read-only.

--- a/modules/nomad/config.tf
+++ b/modules/nomad/config.tf
@@ -33,6 +33,14 @@ locals {
       content = ""
     },
     {
+      # override the default nomad.hcl config from package
+      path    = "/etc/nomad.d/nomad.hcl"
+      tags    = "cloud-init"
+      owner   = "nomad"
+      group   = "nomad"
+      content = ""
+    },
+    {
       path    = "/etc/nomad.d/plugins.hcl"
       tags    = "cloud-init,ignition"
       owner   = "nomad"
@@ -64,6 +72,7 @@ locals {
           datacenter_name = var.datacenter_name
           data_dir        = var.data_dir
           log_level       = var.log_level
+          host_volumes    = var.host_volume
         }
       )
     },

--- a/modules/nomad/main.tf
+++ b/modules/nomad/main.tf
@@ -34,6 +34,7 @@ resource "terraform_data" "manifest" {
         for key, item in var.tls : {
           path    = item.path
           content = item.content
+          tags    = item.tags
           enabled = length(item.content) > 0
         }
       ]

--- a/modules/nomad/templates/client.hcl.tftpl
+++ b/modules/nomad/templates/client.hcl.tftpl
@@ -10,4 +10,10 @@ advertise = {
 client = {
   enabled  = true
   cni_path = "/usr/lib/cni"
+%{ for host_volume_name, host_volume in host_volumes ~}
+  host_volume "${host_volume_name}" {
+    path = "${host_volume.path}"
+    read_only = ${host_volume.read_only}
+  }
+%{ endfor ~}
 }

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -69,31 +69,46 @@ variable "tls" {
     ca_cert = optional(object({
       path    = string
       content = string
+      tags    = string
     }))
     cert_file = optional(object({
       path    = string
       content = string
+      tags    = string
     }))
     key_file = optional(object({
       path    = string
       content = string
+      tags    = string
     }))
   })
   default = {
     ca_cert = {
       path    = "/opt/nomad/tls/ca.pem"
       content = ""
+      tags    = "cloud-init,ignition"
     }
     cert_file = {
       path    = "/opt/nomad/tls/agent.pem"
       content = ""
+      tags    = "cloud-init,ignition"
     }
     key_file = {
       path    = "/opt/nomad/tls/agent.key"
       content = ""
+      tags    = "cloud-init,ignition"
     }
   }
   description = "TLS configuration for Nomad"
+}
+
+variable "host_volume" {
+  type = map(object({
+    path      = string
+    read_only = bool
+  }))
+  default     = {}
+  description = "Host volume configuration for Nomad"
 }
 
 resource "random_id" "gossip_key" {

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -1,0 +1,35 @@
+# Terraform module for running PostgreSQL
+
+This module only works with Debian currently. This module only installs the `postgresql` package without additional
+configuration. You will need to use `nomad-postgres` module to configure and run PostgreSQL.
+
+## Usage
+
+To run `nomad-postgres` module, you need to configure 3 host volumes `postgres-data`, `postgres-socket` and
+`postgres-log` mounting paths specified below and pass their volume name in `nomad-postgres` module configuration.
+
+```terraform
+module "postgres" {
+  source = "github.com/narwhl/blueprint//modules/postgres"
+}
+
+module "nomad" {
+  source = "github.com/narwhl/blueprint//modules/nomad"
+  datacenter_name = "dc1"
+  role            = "server"
+  host_volume     = {
+    "postgres-data" = {
+      path = "/var/lib/postgresql"
+      read_only = false
+    }
+    "postgres-socket" = {
+      path = "/var/run/postgresql"
+      read_only = false
+    }
+    "postgres-log" = {
+      path = "/var/log/postgresql"
+      read_only = false
+    }
+  }
+}
+```

--- a/modules/postgres/config.tf
+++ b/modules/postgres/config.tf
@@ -1,0 +1,4 @@
+locals {
+  users = []
+  configs = []
+}

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -1,0 +1,14 @@
+resource "terraform_data" "manifest" {
+  input = {
+    users = local.users
+    files = local.configs
+    install = {
+      packages = [
+        "postgresql",
+        "pgbackrest"
+      ]
+      repositories  = []
+      systemd_units = []
+    }
+  }
+}

--- a/modules/postgres/outputs.tf
+++ b/modules/postgres/outputs.tf
@@ -1,0 +1,3 @@
+output "manifest" {
+  value = terraform_data.manifest.output
+}


### PR DESCRIPTION
This PR implements `postgres` and `nomad-postgres` module.

`postgres` module outputs configuration to be used in `debian` module (`flatcar` currently not supported). The only functionality currently is installing postgreSQL with apt.

`nomad-postgres` module contains Nomad jobs to run PostgreSQL. It must run on a VM created with `debian` module with `postgres` and `nomad` configured. Set `restore_backup` to `false` run init job to initialize backup repository. Otherwise, set it to `false` to restore latest existing backup.

Not implemented (yet):
- Logic to disable PostgreSQL systemd service (`systemctl mask postgresql`)
- Logic to enable Nomad service (`systemctl enable nomad`)
- Logic to intialize PostgreSQL (should be easily doable, concept similar to the pgbackrest init job)

