### PR TITLE
Password initialization in PostgreSQL Nomad module

### DIFF
--- a/modules/debian/config.tf
+++ b/modules/debian/config.tf
@@ -91,6 +91,7 @@ locals {
           owner   = "root"
           group   = "root"
           mode    = "0644"
+          defer   = false
         },
         {
           path = "/etc/systemd/system/getty@tty1.service.d/override.conf"
@@ -105,6 +106,7 @@ locals {
           owner   = "root"
           group   = "root"
           mode    = "0644"
+          defer   = false
         },
         {
           # Adding 00 prefix to override the precedence of the default file
@@ -119,6 +121,7 @@ locals {
           owner   = "root"
           group   = "root"
           mode    = "0644"
+          defer   = false
         }
       ],
       flatten(var.substrates.*.files)
@@ -128,7 +131,7 @@ locals {
       path        = file.path
       owner       = format("%s:%s", file.owner, file.group)
       permissions = length(file.mode) < 4 ? "0${file.mode}" : file.mode
-      defer       = true # ensure users, packages are created before writing extra files 
+      defer       = file.defer # ensure users, packages are created before writing extra files 
     } if file.enabled == true && !startswith(file.content, "https://") && strcontains(file.tags, lookup(file, "tags", "cloud-init"))
   ]
   repositories = merge(

--- a/modules/debian/variables.tf
+++ b/modules/debian/variables.tf
@@ -116,6 +116,7 @@ variable "substrates" {
       mode    = optional(string, "0644")
       owner   = optional(string, "root")
       group   = optional(string, "root")
+      defer   = optional(bool, false)
       tags    = string
     }))
     install = object({

--- a/modules/nomad-postgres/outputs.tf
+++ b/modules/nomad-postgres/outputs.tf
@@ -1,0 +1,9 @@
+output "postgres_passwords" {
+  value = merge({
+    superuser = random_password.postgres_superuser_password.result
+    }, {
+    for db in local.postgres_init_result : db.user => db.password
+  })
+  sensitive   = true
+  description = "The PostgreSQL passwords generated"
+}

--- a/modules/nomad-postgres/templates/postgres-init.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/postgres-init.nomad.hcl.tftpl
@@ -1,0 +1,36 @@
+job "${job_name}" {
+  datacenters = ["${datacenter_name}"]
+  type        = "batch"
+
+  group "${job_name}" {
+    volume "postgres-socket" {
+      type   = "host"
+      source = "${postgres_socket_host_volume_name}"
+    }
+    task "${job_name}" {
+      driver = "exec"
+      lifecycle {
+        hook    = "poststart"
+        sidecar = false
+      }
+      volume_mount {
+        volume      = "postgres-socket"
+        destination = "/var/run/postgresql"
+      }
+      template {
+        data        = <<EOH
+${init_script}
+EOH
+        destination = "$${NOMAD_TASK_DIR}/init.sql"
+      }
+      config {
+        command = "/usr/bin/psql"
+        args = [
+          "-f",
+          "$${NOMAD_TASK_DIR}/init.sql"
+        ]
+      }
+      user = "postgres"
+    }
+  }
+}

--- a/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
+++ b/modules/nomad-postgres/templates/postgres.nomad.hcl.tftpl
@@ -41,7 +41,7 @@ job "${job_name}" {
 
       config {
         command = "/usr/bin/pg_ctlcluster"
-        args    = [
+        args = [
           "15", "main", "start", "--foreground"
         ]
       }
@@ -56,7 +56,7 @@ EOH
       }
 
       template {
-        data        = <<EOH
+        data = <<EOH
 archive_mode = on
 archive_command = 'pgbackrest --stanza=${pgbackrest_stanza} --config /local/pgbackrest.conf archive-push %p'
 EOH

--- a/modules/nomad-postgres/variables.tf
+++ b/modules/nomad-postgres/variables.tf
@@ -3,6 +3,11 @@ variable "postgres_job_name" {
   default = "postgres"
 }
 
+variable "postgres_init_job_name" {
+  type    = string
+  default = "postgres-init"
+}
+
 variable "backup_schedule" {
   type        = string
   default     = "@weekly"
@@ -22,6 +27,23 @@ variable "pgbackrest_init_job_name" {
 variable "pgbackrest_restore_job_name" {
   type    = string
   default = "pgbackrest-restore"
+}
+
+variable "postgres_init" {
+  type = list(object({
+    database = string
+    user     = optional(string, "")
+    password = optional(string, "")
+  }))
+  default     = []
+  description = "The PostgreSQL databases and users to be created. The user will have the same name as the database if not specified. Leave password empty if it should be generated. Can be in Go (Nomad) template syntax for accessing Consul K/V, Vault secrets or Nomad variables, etc."
+  sensitive   = true
+}
+
+variable "postgres_init_script" {
+  type        = string
+  default     = ""
+  description = "The PostgreSQL database initialization script"
 }
 
 variable "datacenter_name" {

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -38,6 +38,18 @@ variable "role" {
   }
 }
 
+variable "nomad_user" {
+  type        = string
+  default     = ""
+  description = "User running Nomad. Needs to be root if running exec plugin. Defaults to nomad if role is server, or root if role is client"
+}
+
+variable "nomad_group" {
+  type        = string
+  default     = ""
+  description = "Group of user running Nomad. For setting file permissions in config. Defaults to nomad if role is server, or root if role is client"
+}
+
 variable "bootstrap_expect" {
   type        = number
   default     = 1


### PR DESCRIPTION
- set defer flag to false by default to avoid manual restart for reloading nomad config (write-files > run-cmd > write-files-deferred)
- make user running nomad configurable (to avoid writing files with inexist nomad user, also Hashicorp recommends running client with `root` but server with `nomad`)
- add password initialization script
The PostgreSQL database should be able to initialize without any manual intervention (i.e. ssh) after this pull request.