### PR TITLE
Enable gossip key encryption config for Consul client

### DIFF
--- a/modules/consul/config.tf
+++ b/modules/consul/config.tf
@@ -49,6 +49,7 @@ locals {
           data_dir        = var.data_dir
           retry_join      = jsonencode(var.retry_join)
           log_level       = var.log_level
+          gossip_key      = var.gossip_key
         }
       )
       owner = var.consul_user
@@ -61,7 +62,6 @@ locals {
         "${path.module}/templates/server.hcl.tftpl",
         {
           bootstrap_expect = var.bootstrap_expect
-          gossip_key       = local.gossip_key
         }
       )
       enabled = strcontains(var.role, "server")

--- a/modules/consul/templates/client.hcl.tftpl
+++ b/modules/consul/templates/client.hcl.tftpl
@@ -5,3 +5,4 @@ bind_addr      = "{{ GetPrivateIP }}"
 advertise_addr = "{{ GetPrivateIP }}"
 retry_join     = ${retry_join}
 log_level      = "${log_level}"
+encrypt        = "${gossip_key}"

--- a/modules/consul/templates/server.hcl.tftpl
+++ b/modules/consul/templates/server.hcl.tftpl
@@ -1,3 +1,2 @@
 server           = true
 bootstrap_expect = ${bootstrap_expect}
-encrypt          = "${gossip_key}"


### PR DESCRIPTION
All nodes (including non-server nodes) require encryption to communicate

https://developer.hashicorp.com/consul/docs/agent/config/cli-flags#_encrypt