### PR TITLE
feat: allow local config of cloudflare tunnel

### DIFF
--- a/modules/nomad-ingress/templates/cloudflared.nomad.hcl.tftpl
+++ b/modules/nomad-ingress/templates/cloudflared.nomad.hcl.tftpl
@@ -17,11 +17,36 @@ job "${job_name}" {
           "tunnel",
           "--loglevel",
           "debug",
+          %{ for c in local_ingress_config ~}
+          "--config",
+          "$${NOMAD_TASK_DIR}/config.yaml",
+          %{ endfor ~}
           "run",
+          %{ for c in remote_ingress_config ~}
           "--token",
-          "${tunnel_token}",
+          "${c.tunnel_token}",
+          %{ endfor ~}
+          %{ for c in local_ingress_config ~}
+          "${c.tunnel}",
+          %{ endfor ~}
         ]
       }
+
+%{ for c in local_ingress_config ~}
+      template {
+        data = <<EOH
+${c.ingress_config}
+EOH
+        destination = "local/config.yaml"
+      }
+
+      template {
+        data = <<EOH
+${c.tunnel_credentials}
+EOH
+        destination = "secrets/tunnel-credentials.json"
+      }
+%{ endfor ~}
     }
   }
 }

--- a/modules/nomad-ingress/variables.tf
+++ b/modules/nomad-ingress/variables.tf
@@ -23,6 +23,16 @@ variable "cloudflare_account_id" {
   description = "Cloudflare account ID. Leave empty to disable ingress from cloudflare tunnel"
 }
 
+variable "cloudflare_tunnel_config_source" {
+  type        = string
+  description = "Source of the cloudflare tunnel config. Either `local` or `cloudflare`. If `local` is used, the tunnel config will be generated locally. If `cloudflare` is used, the tunnel config will be configured by `cloudflare_tunnel_config` resource."
+  validation {
+    condition     = contains(["local", "cloudflare"], var.cloudflare_tunnel_config_source)
+    error_message = "Invalid cloudflare_tunnel_config_source value. Valid values are `local` and `cloudflare`."
+  }
+  default = "cloudflare"
+}
+
 variable "acme_email" {
   type        = string
   default     = ""


### PR DESCRIPTION
Enable cloudflare tunnel to use local config instead of config from online console. This allows ingress rule to be specified with nomad templates so it can be updated without terraform apply.