### PR TITLE
Source nomad, consul address in traefik ingress configuration from Consul-Nomad Integration

### DIFF
--- a/modules/nomad-ingress/README.md
+++ b/modules/nomad-ingress/README.md
@@ -1,13 +1,53 @@
 # Terraform module for running Traefik as an ingress controller and using cloudflared for traffic gateway on Nomad
 
+Minimal configuration for running the module:
+
 ```hcl
 module "ingress" {
-  datacenter_name       = "dc1"
-  traefik_version       = ""
-  cloudflared_version   = ""
-  dns_zone_name         = "domain.tld"
-  cloudflare_account_id = ""
-  acme_email            = ""
-  static_routes         = ""
+  datacenter_name                 = "dc1"
+  traefik_version                 = ""
+  cloudflared_version             = ""
+  cloudflare_tunnel_config_source = "local" // recommeded to use local as ingress address can be obtained dynamically through nomad-consul integration
+  dns_zone_name                   = "domain.tld"
+  cloudflare_account_id           = "" // leave empty to disable cloudflare tunnel component
+  acme_email                      = ""
+  static_routes                   = "" // static routes defined in traefik dynamic configuration YAML format
 }
 ```
+
+## Nomad Integration
+
+To use nomad service discovery for service discovery, you need to provide the
+following configuration:
+
+```hcl
+module "ingress" {
+  ...
+  nomad_provider_config = {
+    address = "" // leave empty to use the address from the `nomad` consul service (if nomad has consul integration enabled)
+  }
+}
+```
+
+Address is defaulted empty, so by default the address from the `nomad` consul
+service will be used. However, you will at least supply an empty object if you
+use all defaulted values.
+
+## Consul Integration
+
+To use consul catelog for service discovery, you need to provide the following configuration:
+
+```hcl
+module "ingress" {
+  ...
+  consul_provider_config = {
+    address       = "" // leave empty to use the address from the `consul` consul service (if nomad has consul integration enabled)
+    connect_aware = true // whether traefik should discover and connect to consul connect services
+    service_name  = "" // Name of the traefik service in consul. This defaults to the controller job name if not provided
+  }
+}
+```
+
+Address is defaulted empty, so by default the address from the `consul` consul
+service will be used. However, you will at least supply an empty object if you
+use all defaulted values.

--- a/modules/nomad-ingress/README.md
+++ b/modules/nomad-ingress/README.md
@@ -17,12 +17,16 @@ module "ingress" {
 
 ## Nomad Integration
 
-To use nomad service discovery for service discovery, you need to provide the
-following configuration:
+Traefik ingress may be configured to use Nomad service catalog as a source of
+service discovery. In this case, traefik will obtain service catalog from the
+nomad endpoint in the configuration, and add tagged service in Nomad to traefik
+configuration dynamically.
+
+https://doc.traefik.io/traefik/providers/nomad/
 
 ```hcl
 module "ingress" {
-  ...
+  ...// other configurations
   nomad_provider_config = {
     address = "" // leave empty to use the address from the `nomad` consul service (if nomad has consul integration enabled)
   }
@@ -30,24 +34,39 @@ module "ingress" {
 ```
 
 Address is defaulted empty, so by default the address from the `nomad` consul
-service will be used. However, you will at least supply an empty object if you
+service will be used. That is, it will obtain the nomad address from the consul
+service catalog. However, you will at least supply an empty object if you
 use all defaulted values.
 
 ## Consul Integration
 
-To use consul catelog for service discovery, you need to provide the following configuration:
+Traefik ingress may be configured to use Consul service catalog as a source of
+service discovery. This is similar to the nomad integration, but instead of
+using the Nomad service catalog, it will use the Consul service catalog as the
+configuration source. In this case, traefik will obtain service catalog from
+the consul endpoint in the configuration, and add tagged service in Consul to
+traefik configuration dynamically.
+
+Different from Nomad integration, Consul integration has the additonal option
+for configuring whether traefik should discover consul connect enabled
+services. Enabling this option will set traefik job to be Consul connect
+native. Then, traefik ingress will connect to services tagged with connect
+enabled with Consul connect.
+
+https://doc.traefik.io/traefik/providers/consul-catalog/
 
 ```hcl
 module "ingress" {
-  ...
+  ...// other configurations
   consul_provider_config = {
     address       = "" // leave empty to use the address from the `consul` consul service (if nomad has consul integration enabled)
-    connect_aware = true // whether traefik should discover and connect to consul connect services
-    service_name  = "" // Name of the traefik service in consul. This defaults to the controller job name if not provided
+    connect_aware = true // whether traefik should discover and connect to consul connect services, defaults to true
+    service_name  = "" // Name of the traefik service in consul. This defaults to the controller job name if not provided. This is only required if you need to customize the controller service name appeared in Consul catalog.
   }
 }
 ```
 
 Address is defaulted empty, so by default the address from the `consul` consul
-service will be used. However, you will at least supply an empty object if you
-use all defaulted values.
+service will be used. That is, it will obtain the consul address from the
+consul service catalog. However, you will at least supply an empty object if
+you use all defaulted values.

--- a/modules/nomad-ingress/README.md
+++ b/modules/nomad-ingress/README.md
@@ -15,6 +15,53 @@ module "ingress" {
 }
 ```
 
+## Default Traefik Configuration
+
+By default, this module sets up 2 entrypoints for traefik ingress:
+
+- http: 80
+- https: 443
+
+Cloudflare tunnel by default connects to the `http` entrypoint. To make
+services accessible through cloudflare, configure ingress to point to
+the service through the `http` entrypoint.
+
+### Adding Static Routes
+
+The following example shows traefik configuration for adding a static route.
+Put the following in the `static_routes` variable for adding the route via
+the module:
+
+```yaml
+http:
+  routers:
+    my-service:
+      rule: Host(`my-service.domain.tld`)
+      entrypoints:
+        - http
+      service: my-service
+  services:
+    my-service:
+      loadBalancer:
+        servers:
+          - url: http://127.0.0.1:8080
+```
+
+The example sets up a static route for `my-service` with the hostname
+`my-service.domain.tld` to point to the `http` entrypoint. The service would
+be accessible through `http://my-service.domain.tld` after configuring the DNS
+record for `my-service.domain.tld` to point to the ingress address.
+
+```hcl
+resource "cloudflare_record" "tunnel_domains" {
+  zone_id  = "..."
+  name     = "my-service.domain.tld"
+  value    = module.nomad_ingress.cloudflare_tunnel_domain // output of this module
+  type     = "CNAME"
+  proxied  = true
+}
+```
+
 ## Nomad Integration
 
 Traefik ingress may be configured to use Nomad service catalog as a source of
@@ -37,6 +84,28 @@ Address is defaulted empty, so by default the address from the `nomad` consul
 service will be used. That is, it will obtain the nomad address from the consul
 service catalog. However, you will at least supply an empty object if you
 use all defaulted values.
+
+### Attaching Tags to Nomad Services
+
+The below example shows how to attach tags to a nomad service for traefik
+ingress. The example sets up a route for `my-service` with the hostname
+`my-service.domain.tld` to attach to the `http` entrypoint. The service would
+be accessible through `http://my-service.domain.tld` after configuring the
+DNS record for `my-service.domain.tld` to point to the ingress address.
+
+```yaml
+service {
+  name = "my-service"
+  provider = "nomad"
+  tags = [
+    "traefik.enable=true",
+    "traefik.http.routers.my-service.rule=Host(`my-service.domain.tld`)",
+    "traefik.http.routers.my-service.entrypoints=http",
+  ]
+}
+```
+
+Configure the DNS record with the same way as the static route example.
 
 ## Consul Integration
 
@@ -70,3 +139,63 @@ Address is defaulted empty, so by default the address from the `consul` consul
 service will be used. That is, it will obtain the consul address from the
 consul service catalog. However, you will at least supply an empty object if
 you use all defaulted values.
+
+### Attaching Tags to Consul Services
+
+The method for attaching tags to consul services is similar to Nomad. However,
+you need to be aware when using Consul Connect.
+
+#### Without Consul Connect
+
+If you decided not to connect traefik to the service via Consul Connect, you
+can refer to the below example. You will still be able to use Consul connect
+to access other service. Note that sidecar service inherits the tags
+from the service it is attached to. You will need to explicitly disable
+traefik for the sidecar service.
+
+```hcl
+service {
+  name = "my-service"
+  tags = [
+    "traefik.enable=true",
+    "traefik.http.routers.my-service.rule=Host(`my-service.domain.tld`)",
+    "traefik.http.routers.my-service.entrypoints=http",
+  ]
+  connect {
+    sidecar_service {
+      proxy {}
+      tags = [
+        "traefik.enable=false", # disable traefik for sidecar service
+      ]
+    }
+  }
+}
+```
+
+Configure the DNS record with the same way as the static route example.
+
+#### With Consul Connect
+
+To use Consul connect with the service, you will need to explicitly enable
+it by setting `traefik.consulcatalog.connect=true` in the service tags. In
+this case, keep the default tag for sidecar service to inherit the tags from
+parent service.
+
+```hcl
+service {
+  name = "my-service"
+  tags = [
+    "traefik.enable=true",
+    "traefik.http.routers.my-service.rule=Host(`my-service.domain.tld`)",
+    "traefik.http.routers.my-service.entrypoints=http",
+    "traefik.consulcatalog.connect=true", # enable consul connect for the service
+  ]
+  connect {
+    sidecar_service {
+      proxy {}
+    }
+  }
+}
+```
+
+Configure the DNS record with the same way as the static route example.

--- a/modules/nomad-ingress/main.tf
+++ b/modules/nomad-ingress/main.tf
@@ -47,18 +47,6 @@ data "consul_service" "ingress" {
   ]
 }
 
-data "consul_service" "consul" {
-  count      = var.consul_provider_config != null ? (var.consul_provider_config.address == "" ? 1 : 0) : 0
-  name       = "consul"
-  datacenter = var.datacenter_name
-}
-
-data "consul_service" "nomad" {
-  count      = var.nomad_provider_config != null ? (var.nomad_provider_config.address == "" ? 1 : 0) : 0
-  name       = "nomad"
-  datacenter = var.datacenter_name
-}
-
 resource "cloudflare_tunnel_config" "ingress" {
   count      = var.cloudflare_account_id != "" && var.cloudflare_tunnel_config_source == "cloudflare" ? 1 : 0
   account_id = var.cloudflare_account_id
@@ -85,10 +73,11 @@ resource "nomad_job" "ingress-controller" {
         cf_api_token = cloudflare_api_token.dns_challenge_token[0].value
       }]
       nomad_config = var.nomad_provider_config == null ? [] : [{
-        address = var.nomad_provider_config.address == "" ? "http://${data.consul_service.nomad[0].service[0].address}:4646" : var.nomad_provider_config.address
+        # https://github.com/hashicorp/consul-template/blob/main/README.md#multi-phase-execution
+        address = var.nomad_provider_config.address == "" ? "{{ with service `nomad` }}{{ with index . 0 }}http://{{ .Address }}:4646{{ end }}{{ end }}" : var.nomad_provider_config.address
       }]
       consul_config = var.consul_provider_config == null ? [] : [{
-        address       = var.consul_provider_config.address == "" ? "http://${data.consul_service.consul[0].service[0].address}:8500" : var.consul_provider_config.address
+        address       = var.consul_provider_config.address == "" ? "{{ with service `consul` }}{{ with index . 0 }}http://{{ .Address }}:8500{{ end }}{{ end }}" : var.consul_provider_config.address
         connect_aware = var.consul_provider_config.connect_aware
         service_name  = var.consul_provider_config.service_name == "" ? var.controller_job_name : var.consul_provider_config.service_name
         sidecars      = var.consul_provider_config.connect_aware ? [] : [{}]
@@ -121,7 +110,7 @@ resource "nomad_job" "ingress-gateway" {
           tunnel           = cloudflare_tunnel.ingress[0].id
           credentials-file = "{{ env `NOMAD_SECRETS_DIR` }}/tunnel-credentials.json"
           ingress = [{
-            service = "{{ range service `${local.consul_service_name}` }}http://{{ .Address }}:{{ .Port }}{{ end }}"
+            service = "{{ with service `${local.consul_service_name}` }}{{ with index . 0 }}http://{{ .Address }}:{{ .Port }}{{ end }}{{ end }}"
           }]
         })
       }] : []

--- a/modules/nomad-ingress/templates/traefik.nomad.hcl.tftpl
+++ b/modules/nomad-ingress/templates/traefik.nomad.hcl.tftpl
@@ -38,6 +38,57 @@ job "${job_name}" {
       driver = "docker"
 
       template {
+        data = <<EOF
+[api]
+  insecure = true
+  dashboard = true
+  debug = true
+
+[ping]
+
+[log]
+  level = "DEBUG"
+
+[serversTransport]
+  insecureSkipVerify = true
+
+[entryPoints]
+  [entryPoints.http]
+    address = "{{ env `NOMAD_PORT_http` }}"
+  [entryPoints.https]
+    address = "{{ env `NOMAD_PORT_https` }}"
+
+%{ for c in acme_config ~}
+[certificatesResolvers.letsencrypt.acme]
+  email = "${c.acme_email}"
+  storage = "{{ env `NOMAD_ALLOC_DIR` }}/acme.json"
+  [certificatesResolvers.letsencrypt.acme.dnsChallenge]
+    provider = "cloudflare"
+%{ endfor ~}
+
+[providers.file]
+  filename = "/etc/traefik/dynamic.yml"
+
+%{ for c in nomad_config ~}
+[providers.nomad]
+  exposedByDefault = false
+  [providers.nomad.endpoint]
+    address = "${c.address}"
+%{ endfor ~}
+
+%{ for c in consul_config ~}
+[providers.consulCatalog]
+  exposedByDefault = false
+  connectAware = ${c.connect_aware}
+  serviceName = "${c.service_name}"
+  [providers.consulCatalog.endpoint]
+    address = "${c.address}"
+%{ endfor ~}
+EOF
+        destination = "local/traefik.toml"
+      }
+
+      template {
         data        = <<EOF
 ${static_routes}
 EOF
@@ -47,7 +98,7 @@ EOF
 
       template {
         data = <<EOF
-%{ for c in acme_config ~} 
+%{ for c in acme_config ~}
           CF_DNS_API_TOKEN=${c.cf_api_token}
 %{ endfor ~}
 
@@ -59,33 +110,7 @@ EOF
       config {
         image = "traefik:${version}"
         args = [
-          "--api.insecure=true",
-          "--api.dashboard=true",
-          "--api.debug=true",
-          "--ping=true",
-          "--log.level=DEBUG",
-          "--serversTransport.insecureSkipVerify=true",
-          "--entrypoints.http.address=:$${NOMAD_PORT_http}",
-          "--entrypoints.https.address=:$${NOMAD_PORT_https}",
-%{ for c in acme_config ~} 
-          "--certificatesresolvers.letsencrypt.acme.dnschallenge=true",
-          "--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=cloudflare",
-          "--certificatesresolvers.letsencrypt.acme.email=${c.acme_email}",
-          "--certificatesresolvers.letsencrypt.acme.storage=$${NOMAD_ALLOC_DIR}/acme.json",
-%{ endfor ~}
-          "--providers.file.filename=/etc/traefik/dynamic.yml",
-%{ for c in nomad_config ~} 
-          "--providers.nomad=true",
-          "--providers.nomad.endpoint.address=${c.address}",
-          "--providers.nomad.exposedByDefault=false",
-%{ endfor ~} 
-%{ for c in consul_config ~} 
-          "--providers.consulcatalog=true",
-          "--providers.consulcatalog.endpoint.address=${c.address}",
-          "--providers.consulcatalog.connectAware=${c.connect_aware}",
-          "--providers.consulcatalog.serviceName=${c.service_name}",
-          "--providers.consulcatalog.exposedByDefault=false",
-%{ endfor ~} 
+          "--configfile=$${NOMAD_TASK_DIR}/traefik.toml"
         ]
 
         mount {

--- a/modules/nomad-ingress/variables.tf
+++ b/modules/nomad-ingress/variables.tf
@@ -74,18 +74,18 @@ variable "static_routes" {
 
 variable "nomad_provider_config" {
   type = object({
-    address = string
+    address = optional(string, "")
   })
   default     = null
-  description = "Configuration for Nomad Traefik integration. The address from Cousul `nomad` service will be used if address is left empty. TLS is not supported at the moment."
+  description = "Configuration for Nomad Traefik integration. The address from Cousul `nomad` service will be used if address is left empty. TLS is not supported at the moment. Note that nomad service discovery will only enable if the config value is not null. You need to supply an empty object if you use all defaulted values."
 }
 
 variable "consul_provider_config" {
   type = object({
-    address       = string
-    connect_aware = bool
-    service_name  = string
+    address       = optional(string, "")
+    connect_aware = optional(bool, true)
+    service_name  = optional(string, "")
   })
   default     = null
-  description = "Configuration for Consul Traefik integration. The address from Consul `consul` service will be used if address is left empty. TLS is not supported at the moment."
+  description = "Configuration for Consul Traefik integration. The address from Consul `consul` service will be used if address is left empty. TLS is not supported at the moment. Note that consul service discovery will only enable if the config value is not null. You need to supply an empty object if you use all defaulted values."
 }


### PR DESCRIPTION
Currently, the nomad, consul addresses in traefik ingress configuration are source from Consul terraform provider. The addresses are only read during applying Terraform configuration. In case of IP changes in nomad/consul (e.g. a node is down), the Terraform configuration needs to be reapplied to update the address.

To solve this issue, the traefik configuration is changed to use nomad template. With consul integration enabled, traefik would be able to obtain both nomad and consul address through the template. The template will update automatically, and configuration will be reloaded to reflect the latest address change.