### PR TITLE
Fix Consul service datasource not being disabled when using local tunnel source

### DIFF
--- a/modules/nomad-ingress/README.md
+++ b/modules/nomad-ingress/README.md
@@ -15,6 +15,24 @@ module "ingress" {
 }
 ```
 
+## Cloudflare Tunnel Configuration Source
+
+Cloudflare tunnel have two modes of configuration source, which can be
+specified via `cloudflare_tunnel_config_source` variable:
+
+- local: cloudflare uses the tunnel configuration from local configuration file
+in the container. The module uses the template functionality in Nomad to render
+a dynamic configuration file pointing to `traefik` address depending on
+`traefik` consul service address at runtime.
+- cloudflare: cloudflare uses the tunnel configuration from the cloudflare. The
+module will fetch `traefik` address from the `traefik` consul service while
+applying the Terraform configuration and upload the tunnel configuration to
+cloudflare during Terraform apply.
+
+You are recommendend to use `local` as configuration source as the ingress
+config can be updated dynamically without the need of re-applying the Terraform
+configuration.
+
 ## Default Traefik Configuration
 
 By default, this module sets up 2 entrypoints for traefik ingress:

--- a/modules/nomad-ingress/main.tf
+++ b/modules/nomad-ingress/main.tf
@@ -43,6 +43,7 @@ resource "cloudflare_api_token" "dns_challenge_token" {
 }
 
 data "consul_service" "ingress" {
+  count      = var.cloudflare_account_id != "" && var.cloudflare_tunnel_config_source == "cloudflare" ? 1 : 0
   name       = local.consul_service_name
   datacenter = var.datacenter_name
 
@@ -59,7 +60,7 @@ resource "cloudflare_tunnel_config" "ingress" {
 
   config {
     ingress_rule {
-      service = "http://${data.consul_service.ingress.service[0].address}:${data.consul_service.ingress.service[0].port}"
+      service = "http://${data.consul_service.ingress[0].service[0].address}:${data.consul_service.ingress[0].service[0].port}"
     }
   }
 


### PR DESCRIPTION
Currently, `data.consul_service.ingress` is still being queried even when tunnel config source is set to `local`. This will cause problems if `CONSUL_HTTP_ADDR` is not correctly pointed to the consul cluster. This pull request fixes the issue by adding back a count condition to the data source and add a description in README to clarify the option. 