### PR TITLE
fix(idp): fix passkey domain and add options for settings webhook

### DIFF
--- a/modules/nomad-ory-hydra-kratos/config.tf
+++ b/modules/nomad-ory-hydra-kratos/config.tf
@@ -66,12 +66,12 @@ locals {
           enabled = true
         }
         webauthn = {
-          enabled = true
+          enabled = var.kratos_webauthn_enabled
           config = {
             passwordless = true
             rp = {
               display_name = var.application_name
-              id           = var.root_domain
+              id           = local.kratos_ui_fqdn
               origin       = local.kratos_ui_url
             }
           }
@@ -81,7 +81,7 @@ locals {
           config = {
             rp = {
               display_name = var.application_name
-              id           = var.root_domain
+              id           = local.kratos_ui_fqdn
               origin       = local.kratos_ui_url
             }
           }
@@ -95,6 +95,20 @@ locals {
 
         settings = {
           ui_url = "${local.kratos_ui_url}/settings"
+
+          after = {
+            hooks = [for webhook in var.settings_webhooks :
+              {
+                hook = "web_hook"
+                config = {
+                  url     = webhook.url
+                  method  = webhook.method
+                  headers = webhook.headers
+                  body    = "base64://${base64encode(webhook.body)}"
+                }
+              }
+            ]
+          }
         }
 
         recovery = {

--- a/modules/nomad-ory-hydra-kratos/variables.tf
+++ b/modules/nomad-ory-hydra-kratos/variables.tf
@@ -86,6 +86,11 @@ variable "kratos_registration_enabled" {
   default = true
 }
 
+variable "kratos_webauthn_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "kratos_passkey_enabled" {
   type    = bool
   default = false
@@ -119,6 +124,17 @@ variable "registration_webhooks" {
   default = []
 }
 
+variable "settings_webhooks" {
+  type = list(object({
+    url     = string
+    method  = string
+    headers = map(string)
+    body    = string
+  }))
+  default     = []
+  description = "Webhooks to call after settings are updated"
+}
+
 variable "traefik_entrypoint" {
   type = object({
     http  = optional(string, "http")
@@ -135,5 +151,6 @@ locals {
   hydra_fqdn         = "${var.hydra_subdomain}.${var.root_domain}"
   kratos_public_fqdn = "${var.kratos_public_subdomain}.${var.root_domain}"
   kratos_admin_fqdn  = "${var.kratos_admin_subdomain}.${var.root_domain}"
+  kratos_ui_fqdn     = "${var.kratos_ui_subdomain}.${var.root_domain}"
   kratos_ui_url      = "https://${var.kratos_ui_subdomain}.${var.root_domain}"
 }


### PR DESCRIPTION
This pull request works with the `idp` module. It fixes the passkey domain which requires the `kratos_ui_fqdn` instead of root domain. It also exposes options for webauthn keys and settings changed webhook.