### PR TITLE
fix: enable kratos mail delivery and add email options

### DIFF
--- a/modules/nomad-ory-hydra-kratos/config.tf
+++ b/modules/nomad-ory-hydra-kratos/config.tf
@@ -195,6 +195,8 @@ locals {
     courier = {
       smtp = {
         connection_uri = var.smtp_connection_uri
+        from_address   = var.email_from_address
+        from_name      = var.email_from_name
       }
     }
 

--- a/modules/nomad-ory-hydra-kratos/templates/jobspec.nomad.hcl.tftpl
+++ b/modules/nomad-ory-hydra-kratos/templates/jobspec.nomad.hcl.tftpl
@@ -242,7 +242,12 @@ ${kratos_config}
         args = [
           "serve",
           "-c",
-          "/etc/config/kratos/kratos.yml"
+          "/etc/config/kratos/kratos.yml",
+          # Note that Kratos expects the courier to be a singleton.
+          # The courier needs to be run as a separate singleton if Kratos
+          # needs to be scaled to multiple instances.
+          # https://www.ory.sh/docs/kratos/self-hosted/mail-courier-selfhosted
+          "--watch-courier",
         ]
 
         mount {

--- a/modules/nomad-ory-hydra-kratos/variables.tf
+++ b/modules/nomad-ory-hydra-kratos/variables.tf
@@ -114,6 +114,17 @@ variable "smtp_connection_uri" {
   sensitive = true
 }
 
+variable "email_from_address" {
+  type        = string
+  description = "The email address to send emails from"
+}
+
+variable "email_from_name" {
+  type        = string
+  default     = "Account Notifications"
+  description = "The name to use when sending emails"
+}
+
 variable "registration_webhooks" {
   type = list(object({
     url     = string


### PR DESCRIPTION
This pull requests enables Kratos mail courier for sending account verification and recovery emails, as instructed in https://www.ory.sh/docs/kratos/self-hosted/mail-courier-selfhosted. Currently, `--watch-courier` is used as we do not plan on scaling up Kratos to multiple instances in a short term.

This PR also adds options for the `from` email. The `from` email address and name is now configurable via module options.