### PR TITLE
feat: allow cloudflare tunnel using http2 protocol

### DIFF
--- a/modules/nomad-ingress/main.tf
+++ b/modules/nomad-ingress/main.tf
@@ -105,6 +105,7 @@ resource "nomad_job" "ingress-gateway" {
       datacenter_name = var.datacenter_name
       namespace       = var.namespace
       version         = var.cloudflared_version
+      http2_config    = var.use_https ? [{}] : []
       remote_ingress_config = var.cloudflare_tunnel_config_source == "cloudflare" ? [{
         tunnel_token = cloudflare_tunnel.ingress[0].tunnel_token
       }] : []

--- a/modules/nomad-ingress/templates/cloudflared.nomad.hcl.tftpl
+++ b/modules/nomad-ingress/templates/cloudflared.nomad.hcl.tftpl
@@ -18,6 +18,10 @@ job "${job_name}" {
           "tunnel",
           "--loglevel",
           "debug",
+          %{ for c in http2_config ~}
+          "--protocol",
+          "http2",
+          %{ endfor ~}
           %{ for c in local_ingress_config ~}
           "--config",
           "$${NOMAD_TASK_DIR}/config.yaml",


### PR DESCRIPTION
This pull request adds command line argument `--protocol http2` to cloudflare tunnel argument, and it is enabled when https is used. This allows GRPC request, which requires http2, to be made through cloudflare tunnel. HTTPS is required due to cloudflare's [requirement](https://developers.cloudflare.com/network/grpc-connections/) of `full` encryption mode of gRPC.

This GitHub issue has more details on gRPC support for cloudflare tunnel: https://github.com/cloudflare/cloudflared/issues/491