### PR TITLE
feat: rewrite temporal module with external postgresql

### DIFF
--- a/modules/nomad-temporal/README.md
+++ b/modules/nomad-temporal/README.md
@@ -1,0 +1,22 @@
+# Terraform module for self hosting Temporal on Nomad
+
+This module deploys Temporal on Nomad. It uses PostgreSQL as the underlying
+database. Elasticsearch is disabled and PostgreSQL is used for the visibility
+database.
+
+## Example Configuration
+
+```hcl
+module "temporal" {
+  source                       = "registry.narwhl.workers.dev/stack/temporal/nomad"
+  datacenter_name              = local.datacenter_name
+  postgres_host                = "{{ with service `postgres-rw` }}{{ with index . 0 }}{{ .Address }}{{ end }}{{ end }}"
+  postgres_port                = "{{ with service `postgres-rw` }}{{ with index . 0 }}{{ .Port }}{{ end }}{{ end }}"
+  postgres_username            = "temporal"
+  postgres_database            = "temporal"
+  postgres_visibility_database = "temporal_visibility"
+  postgres_password            = "{{ with nomadVar `nomad/jobs/postgres` }}{{ .temporal_password }}{{ end }}"
+  temporal_version             = "1.26.2"
+  temporal_ui_version          = "2.31.2"
+}
+```

--- a/modules/nomad-temporal/main.tf
+++ b/modules/nomad-temporal/main.tf
@@ -1,23 +1,20 @@
-resource "random_password" "db_password" {
-  length           = 32
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
-}
-
 resource "nomad_job" "temporal" {
   jobspec = templatefile(
     "${path.module}/templates/temporal.nomad.hcl.tftpl",
     {
-      job_name              = var.job_name
-      datacenter_name       = var.datacenter_name
-      namespace             = var.namespace
-      elasticsearch_version = var.elasticsearch_version
-      postgres_version      = var.postgres_version
-      temporal_version      = var.temporal_version
-      temporal_ui_version   = var.temporal_ui_version
-      db_password           = random_password.db_password.result
-      db_username           = var.postgres_username
+      job_name            = var.job_name
+      service_name        = var.service_name
+      datacenter_name     = var.datacenter_name
+      namespace           = var.namespace
+      temporal_version    = var.temporal_version
+      temporal_ui_version = var.temporal_ui_version
+      db_password         = var.postgres_password
+      db_user             = var.postgres_username
+      db_host             = var.postgres_host
+      db_port             = var.postgres_port
+      db_name             = var.postgres_database
+      visibility_db_name  = var.postgres_visibility_database
     }
   )
-  purge_on_destroy = true
+  purge_on_destroy = var.purge_on_destroy
 }

--- a/modules/nomad-temporal/templates/temporal.nomad.hcl.tftpl
+++ b/modules/nomad-temporal/templates/temporal.nomad.hcl.tftpl
@@ -3,64 +3,6 @@ job "${job_name}" {
   namespace   = "${namespace}"
   type        = "service"
 
-  group "database" {
-    network {
-      mode = "bridge"
-      port "postgres" {
-        to = 5432
-      }
-    }
-    service {
-      provider = "nomad"
-      name     = "temporal-postgres"
-      port     = "postgres"
-    }
-    task "postgres" {
-      driver = "docker"
-      config {
-        image = "postgres:${postgres_version}"
-        ports = ["postgres"]
-      }
-      env {
-        POSTGRES_PASSWORD = "${db_password}"
-        POSTGRES_USER     = "${db_username}"
-      }
-    }
-  }
-
-  group "elasticsearch" {
-    network {
-      mode = "bridge"
-      port "elasticsearch" {
-        to = 9200
-      }
-    }
-    service {
-      provider = "nomad"
-      name     = "temporal-elasticsearch"
-      port     = "elasticsearch"
-    }
-    task "elasticsearch" {
-      driver = "docker"
-      config {
-        image = "elasticsearch:${elasticsearch_version}"
-        ports = ["elasticsearch"]
-      }
-      env = {
-        "cluster.routing.allocation.disk.threshold_enabled"     = true
-        "cluster.routing.allocation.disk.watermark.low"         = "512mb"
-        "cluster.routing.allocation.disk.watermark.high"        = "256mb"
-        "cluster.routing.allocation.disk.watermark.flood_stage" = "128mb"
-        "discovery.type"                                        = "single-node"
-        "ES_JAVA_OPTS"                                          = "-Xms256m -Xmx256m"
-        "xpack.security.enabled"                                = "false"
-      }
-      resources {
-        memory = 1024
-      }
-    }
-  }
-
   group "temporal" {
     network {
       mode = "bridge"
@@ -70,36 +12,27 @@ job "${job_name}" {
     }
     service {
       provider = "nomad"
-      name     = "temporal"
+      name     = "${service_name}"
       port     = "temporal"
     }
     task "temporal" {
       driver = "docker"
       config {
         image = "temporalio/auto-setup:${temporal_version}"
-        labels = {
-          "kompose.volume.type" = "configMap"
-        }
         ports = ["temporal"]
-      }
-      env = {
-        "DB"                       = "postgresql"
-        "POSTGRES_USER"            = "temporal"
-        "POSTGRES_PWD"             = "${db_password}"
-        "DYNAMIC_CONFIG_FILE_PATH" = "$${NOMAD_TASK_DIR}/dynamicconfig.yaml"
-        "ENABLE_ES"                = true
-        "ES_VERSION"               = "v7"
       }
       template {
         data        = <<-EOT
-        {{ range nomadService "temporal-postgres" -}}
-        POSTGRES_SEEDS={{ .Address }}
-        DB_PORT={{ .Port }}
-        {{- end }}
-        {{ range nomadService "temporal-elasticsearch" -}}
-        ES_SEEDS={{ .Address }}
-        ES_PORT={{ .Port }}
-        {{- end }}
+        DB=postgres12
+        POSTGRES_SEEDS=${db_host}
+        DB_PORT=${db_port}
+        POSTGRES_USER=${db_user}
+        POSTGRES_PWD=${db_password}
+        DBNAME=${db_name}
+        VISIBILITY_DBNAME=${visibility_db_name}
+        SKIP_DB_CREATE=true
+        ENABLE_ES=false
+        DYNAMIC_CONFIG_FILE_PATH=/local/dynamicconfig.yaml
         EOT
         destination = "secrets/.env"
         env         = true
@@ -109,15 +42,12 @@ job "${job_name}" {
         limit.maxIDLength:
           - value: 255
             constraints: {}
-        system.forceSearchAttributesCacheRefreshOnRead:
-          - value: true
-            constraints: {}
         EOT
         destination = "local/dynamicconfig.yaml"
       }
     }
   }
-  
+
   group "temporal-ui" {
     network {
       mode = "bridge"
@@ -127,7 +57,7 @@ job "${job_name}" {
     }
     service {
       provider = "nomad"
-      name     = "temporal-ui"
+      name     = "${service_name}-ui"
       port     = "temporal-ui"
     }
     task "temporal-ui" {
@@ -141,31 +71,7 @@ job "${job_name}" {
       }
       template {
         data        = <<-EOT
-        {{ range nomadService "temporal" -}}
-        TEMPORAL_ADDRESS={{ .Address }}:{{ .Port }}
-        {{- end }}
-        EOT
-        destination = "secrets/.env"
-        env         = true
-      }
-    }
-  }
-  
-  group "temporal-admin-tools" {
-    network {
-      mode = "bridge"
-    }
-    task "admin-tools" {
-      driver = "docker"
-      config {
-        image = "temporalio/admin-tools:${temporal_version}"
-      }
-      template {
-        data        = <<-EOT
-        {{ range nomadService "temporal" -}}
-        TEMPORAL_ADDRESS={{ .Address }}:{{ .Port }}
-        TEMPORAL_CLI_ADDRESS={{ .Address }}:{{ .Port }}
-        {{- end }}
+        TEMPORAL_ADDRESS={{ with nomadService "${service_name}" }}{{ with index . 0 }}{{ .Address }}:{{ .Port }}{{ end }}{{ end }}
         EOT
         destination = "secrets/.env"
         env         = true

--- a/modules/nomad-temporal/variables.tf
+++ b/modules/nomad-temporal/variables.tf
@@ -3,6 +3,12 @@ variable "job_name" {
   default = "temporal"
 }
 
+variable "service_name" {
+  type        = string
+  description = "Name of the service advertised to service discovery"
+  default     = "temporal"
+}
+
 variable "datacenter_name" {
   type        = string
   description = "Name of datacenter to deploy jobs to"
@@ -18,22 +24,16 @@ variable "namespace" {
   default = "default"
 }
 
-variable "elasticsearch_version" {
+variable "postgres_host" {
   type        = string
-  description = "Elasticsearch version"
-  validation {
-    condition     = length(var.elasticsearch_version) > 0
-    error_message = "Elasticsearch version must be set"
-  }
+  description = "Hostname for Postgres"
+  default     = "{{ with service `postgres-rw` }}{{ with index . 0 }}{{ .Address }}{{ end }}{{ end }}"
 }
 
-variable "postgres_version" {
+variable "postgres_port" {
   type        = string
-  description = "Postgresql server version"
-  validation {
-    condition     = length(var.postgres_version) > 0
-    error_message = "Postgresql server version must be set"
-  }
+  description = "Port for Postgres"
+  default     = "{{ with service `postgres-rw` }}{{ with index . 0 }}{{ .Port }}{{ end }}{{ end }}"
 }
 
 variable "postgres_username" {
@@ -43,6 +43,35 @@ variable "postgres_username" {
   validation {
     condition     = length(var.postgres_username) > 0
     error_message = "Postgres username cannot be empty"
+  }
+}
+
+variable "postgres_password" {
+  type        = string
+  description = "Password for authenticating to Postgres"
+  validation {
+    condition     = length(var.postgres_password) > 0
+    error_message = "Postgres password cannot be empty"
+  }
+}
+
+variable "postgres_database" {
+  type        = string
+  description = "Database name for Postgres"
+  default     = "temporal"
+  validation {
+    condition     = length(var.postgres_database) > 0
+    error_message = "Postgres database cannot be empty"
+  }
+}
+
+variable "postgres_visibility_database" {
+  type        = string
+  description = "Visibility database name for Postgres"
+  default     = "temporal_visibility"
+  validation {
+    condition     = length(var.postgres_visibility_database) > 0
+    error_message = "Postgres visibility database cannot be empty"
   }
 }
 
@@ -62,4 +91,10 @@ variable "temporal_ui_version" {
     condition     = length(var.temporal_ui_version) > 0
     error_message = "Temporal UI version must be set"
   }
+}
+
+variable "purge_on_destroy" {
+  type        = bool
+  description = "Whether to purge all Temporal jobs on destroy"
+  default     = false
 }


### PR DESCRIPTION
This PR partially rewrite temporal module according to cleahealth/infrastructure#3. The module now uses an external PostgreSQL instead of hosting one within the group. Elasticsearch is also disabled in favor of using PostgreSQL as the visibility database.
