### PR TITLE
fix: remove invalid temporal module output

### DIFF
--- a/modules/nomad-temporal/outputs.tf
+++ b/modules/nomad-temporal/outputs.tf
@@ -1,7 +1,0 @@
-output "postgres_username" {
-  value = var.postgres_username
-}
-
-output "postgres_password" {
-  value = random_password.db_password.result
-}


### PR DESCRIPTION
This pull request removes the invalid `outputs.tf` in `temporal` module. As of #40, PostgreSQL will be delegrated to external source and PostgreSQL user generation will not be relevant anymore. However, the file removal change did not get synchronized in #40, resulting an [invalid module](https://github.com/narwhl/blueprint/actions/runs/12869040056). This PR should fix this issue.