### PR TITLE
Proxmox terraform module 2.0

### DIFF
--- a/modules/proxmox/proxmox.tf
+++ b/modules/proxmox/proxmox.tf
@@ -23,8 +23,6 @@ resource "proxmox_virtual_environment_vm" "this" {
   bios    = local.boot_mode
   machine = local.machine
 
-  kvm_arguments = local.kvm_arguments
-
   cpu {
     architecture = "x86_64"
     cores        = var.vcpus

--- a/modules/proxmox/terraform.tf
+++ b/modules/proxmox/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = "~> 0.69.1"
+      version = "~> 0.78.2"
     }
   }
 }

--- a/modules/proxmox/variables.tf
+++ b/modules/proxmox/variables.tf
@@ -167,16 +167,6 @@ locals {
     }
   ]
 
-  kvm_arguments = {
-    "ignition" = format(
-      "-fw_cfg name=opt/org.flatcar-linux/config,file=%s/%s.ign",
-      var.snippet_stored_path,
-      sha256(var.provisioning_config.payload)
-    )
-    "cloud-init" = ""
-    "talos"      = ""
-  }[var.provisioning_config.type]
-
   provisioning_config_file_format = {
     "ignition"   = "ign"
     "cloud-init" = "yaml"
@@ -193,7 +183,7 @@ locals {
   }[var.firmware]
 
   initialization = {
-    "ignition"   = {}
+    "ignition"   = { "${var.provisioning_config.type}" = "" }
     "cloud-init" = { "${var.provisioning_config.type}" = "" }
     "talos"      = { "${var.provisioning_config.type}" = "" }
   }[var.provisioning_config.type]


### PR DESCRIPTION
This PR bumps the bpg provider version from 0.69.1 to 0.78.2 and deprecate kernel args passed to qemu tailor for flatcar linux initialization from ignition config file, instead it now requires user to have flatcar proxmox image ready in proxmox and uses provider native `initialization` block for injecting ignition config