### PR TITLE
Create Valkey Nomad module

### DIFF
--- a/modules/nomad-valkey/README.md
+++ b/modules/nomad-valkey/README.md
@@ -1,0 +1,59 @@
+# Terraform module for self hosting Valkey on Nomad
+
+## Usage
+
+```hcl
+module "valkey" {
+  source                = "registry.narwhl.workers.dev/stack/valkey/nomad"
+  datacenter_name       = local.datacenter_name # Nomad datacenter name
+  valkey_version        = "8"                   # Valkey version
+  enable_ephemeral_disk = true                  # Enable Nomad ephemeral disk for the storing valkey data temporarily. Cannot be used with host volumes.
+  purge_on_destroy      = true                  # Purge Valkey job on destroy
+}
+```
+
+### Persistent data
+
+To enable persistent data, provide persistent volume configuration.
+
+```hcl
+module "valkey" {
+...
+  persistent_config = {
+    save_options = "60 1000" # dump the dataset to disk every 60 seconds if at least 1000 keys changed
+  }
+}
+```
+
+The data will be persisted to `/data`. One may mount host volumes to `/data`
+for persisting valkey data.
+
+```hcl
+module "valkey" {
+...
+  host_volume_config = {
+    source = "host-volume-name"
+    read_only = false
+  }
+}
+```
+
+Remember to update `/etc/nomad.d/nomad.hcl` configuration to create the host
+volume. This should be under the `client` stanza.
+
+```hcl
+host_volume "host-volume-name" {
+  path      = "/opt/valkey/data"
+  read_only = false
+}
+```
+
+Alternatively, you may use the `enable_ephemeral_disk` to enable ephemeral disk
+for storing valkey snapshots temporarily.
+
+```hcl
+module "valkey" {
+...
+  enable_ephemeral_disk = true # Enable Nomad ephemeral disk for the storing valkey data temporarily. Cannot be used with host volumes.
+}
+```

--- a/modules/nomad-valkey/main.tf
+++ b/modules/nomad-valkey/main.tf
@@ -1,0 +1,18 @@
+resource "nomad_job" "valkey" {
+  jobspec = templatefile("${path.module}/templates/valkey.nomad.hcl.tftpl", {
+    job_name        = var.job_name
+    datacenter_name = var.datacenter_name
+    namespace       = var.namespace
+    valkey_version  = var.valkey_version
+    host_volume_configs = var.host_volume_config != null ? [
+      {
+        source    = var.host_volume_config.source
+        read_only = var.host_volume_config.read_only
+      }
+    ] : []
+    ephemeral_disk_configs = var.enable_ephemeral_disk ? [{}] : []
+    persistent_configs     = var.persistent_config != null ? [var.persistent_config] : []
+    resources              = var.resources
+  })
+  purge_on_destroy = var.purge_on_destroy
+}

--- a/modules/nomad-valkey/templates/valkey.nomad.hcl.tftpl
+++ b/modules/nomad-valkey/templates/valkey.nomad.hcl.tftpl
@@ -1,0 +1,66 @@
+job "${job_name}" {
+  datacenters = ["${datacenter_name}"]
+  namespace   = "${namespace}"
+  type        = "service"
+
+  group "valkey" {
+
+%{ for config in host_volume_configs ~}
+    volume "valkey-data" {
+      type      = "host"
+      source    = "${config.source}"
+      read_only = ${config.read_only}
+    }
+%{ endfor ~}
+
+%{ for config in ephemeral_disk_configs ~}
+    ephemeral_disk {
+      size = 500
+    }
+%{ endfor ~}
+
+    network {
+      mode = "bridge"
+      port "valkey" {
+        to = 6379
+      }
+    }
+
+    service {
+      name = "valkey"
+      port = "valkey"
+      provider = "nomad"
+    }
+
+    task "valkey" {
+      driver = "docker"
+
+      config {
+        image = "valkey/valkey:${valkey_version}"
+        ports = ["valkey"]
+        args = [
+          "valkey-server",
+%{ for config in persistent_configs ~}
+          "--save",
+          "${config.save_options}",
+%{ endfor ~}
+%{ for config in ephemeral_disk_configs ~}
+          "--dir",
+          "/alloc/data",
+%{ endfor ~}
+        ]
+      }
+%{ for config in host_volume_configs ~}
+      volume_mount {
+        volume      = "valkey-data"
+        destination = "/data"
+        read_only   = ${config.read_only}
+      }
+%{ endfor ~}
+      resources {
+        cpu    = ${resources.cpu}
+        memory = ${resources.memory}
+      }
+    }
+  }
+}

--- a/modules/nomad-valkey/terraform.tf
+++ b/modules/nomad-valkey/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    nomad = {
+      source  = "hashicorp/nomad"
+      version = "2.2.0"
+    }
+  }
+}

--- a/modules/nomad-valkey/variables.tf
+++ b/modules/nomad-valkey/variables.tf
@@ -1,0 +1,64 @@
+variable "datacenter_name" {
+  type        = string
+  description = "Name of the datacenter"
+  validation {
+    condition     = length(var.datacenter_name) > 0
+    error_message = "Datacenter name cannot be empty"
+  }
+}
+
+variable "namespace" {
+  type    = string
+  default = "default"
+}
+
+variable "job_name" {
+  default     = "valkey"
+  description = "Nomad job name"
+}
+
+variable "valkey_version" {
+  default     = "8"
+  description = "valkey version to be deployed"
+}
+
+variable "host_volume_config" {
+  type = object({
+    source    = string
+    read_only = optional(bool, false)
+  })
+  nullable    = true
+  default     = null
+  description = "Host volume configuration for storing valkey data"
+}
+
+variable "enable_ephemeral_disk" {
+  type        = bool
+  default     = false
+  description = "Enable Nomad ephemeral disk for the storing valkey data temporarily. Cannot be used with host volumes."
+}
+
+variable "purge_on_destroy" {
+  type        = bool
+  default     = false
+  description = "Purge the Typesense Nomad job on destroy"
+}
+
+variable "persistent_config" {
+  type = object({
+    save_options = optional(string, "60 1")
+  })
+  description = "Persistent configuration for valkey"
+}
+
+variable "resources" {
+  type = object({
+    cpu    = optional(number, 1000)
+    memory = optional(number, 2048)
+  })
+  default = {
+    cpu    = 1000
+    memory = 2048
+  }
+  description = "Resources to run the job with"
+}


### PR DESCRIPTION
This PR creates the `valkey` module, using the current `redis` module as a starting point. As the current valkey version is fully compatible with redis, there is no changes apart from the image name and variable names.