### PR TITLE
feat(nomad-valkey): add support for dynamic host volumes 

### DIFF
--- a/modules/nomad-valkey/main.tf
+++ b/modules/nomad-valkey/main.tf
@@ -1,13 +1,39 @@
+resource "nomad_dynamic_host_volume" "valkey_data" {
+  count = var.dynamic_host_volume_config != null ? 1 : 0
+
+  name         = var.dynamic_host_volume_config.name
+  plugin_id    = var.dynamic_host_volume_config.plugin_id
+  node_pool    = var.dynamic_host_volume_config.node_pool
+  capacity_min = var.dynamic_host_volume_config.capacity_min
+  capacity_max = var.dynamic_host_volume_config.capacity_max
+  parameters   = var.dynamic_host_volume_config.parameters
+
+  dynamic "capability" {
+    for_each = var.dynamic_host_volume_config.capability != null ? [var.dynamic_host_volume_config.capability] : []
+    content {
+      access_mode     = capability.value.access_mode
+      attachment_mode = capability.value.attachment_mode
+    }
+  }
+}
+
 resource "nomad_job" "valkey" {
   jobspec = templatefile("${path.module}/templates/valkey.nomad.hcl.tftpl", {
     job_name        = var.job_name
     datacenter_name = var.datacenter_name
     namespace       = var.namespace
     valkey_version  = var.valkey_version
+    # Legacy host volume support (deprecated)
     host_volume_configs = var.host_volume_config != null ? [
       {
         source    = var.host_volume_config.source
         read_only = var.host_volume_config.read_only
+      }
+    ] : []
+    # Dynamic host volume support
+    dynamic_host_volume_configs = var.dynamic_host_volume_config != null ? [
+      {
+        name = var.dynamic_host_volume_config.name
       }
     ] : []
     ephemeral_disk_configs = var.enable_ephemeral_disk ? [{}] : []
@@ -15,4 +41,6 @@ resource "nomad_job" "valkey" {
     resources              = var.resources
   })
   purge_on_destroy = var.purge_on_destroy
+
+  depends_on = [nomad_dynamic_host_volume.valkey_data]
 }

--- a/modules/nomad-valkey/outputs.tf
+++ b/modules/nomad-valkey/outputs.tf
@@ -1,0 +1,14 @@
+output "job_name" {
+  description = "The name of the Valkey Nomad job"
+  value       = nomad_job.valkey.name
+}
+
+output "dynamic_host_volume_id" {
+  description = "The ID of the dynamic host volume (if created)"
+  value       = var.dynamic_host_volume_config != null ? nomad_dynamic_host_volume.valkey_data[0].id : null
+}
+
+output "dynamic_host_volume_name" {
+  description = "The name of the dynamic host volume (if created)"
+  value       = var.dynamic_host_volume_config != null ? nomad_dynamic_host_volume.valkey_data[0].name : null
+}

--- a/modules/nomad-valkey/templates/valkey.nomad.hcl.tftpl
+++ b/modules/nomad-valkey/templates/valkey.nomad.hcl.tftpl
@@ -13,6 +13,13 @@ job "${job_name}" {
     }
 %{ endfor ~}
 
+%{ for config in dynamic_host_volume_configs ~}
+    volume "valkey-data" {
+      type   = "csi"
+      source = "${config.name}"
+    }
+%{ endfor ~}
+
 %{ for config in ephemeral_disk_configs ~}
     ephemeral_disk {
       size = 500
@@ -55,6 +62,12 @@ job "${job_name}" {
         volume      = "valkey-data"
         destination = "/data"
         read_only   = ${config.read_only}
+      }
+%{ endfor ~}
+%{ for config in dynamic_host_volume_configs ~}
+      volume_mount {
+        volume      = "valkey-data"
+        destination = "/data"
       }
 %{ endfor ~}
       resources {

--- a/modules/nomad-valkey/terraform.tf
+++ b/modules/nomad-valkey/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nomad = {
       source  = "hashicorp/nomad"
-      version = "2.2.0"
+      version = "~> 2.4"
     }
   }
 }

--- a/modules/nomad-valkey/variables.tf
+++ b/modules/nomad-valkey/variables.tf
@@ -29,7 +29,25 @@ variable "host_volume_config" {
   })
   nullable    = true
   default     = null
-  description = "Host volume configuration for storing valkey data"
+  description = "Host volume configuration for storing valkey data (deprecated - use dynamic_host_volume_config instead)"
+}
+
+variable "dynamic_host_volume_config" {
+  type = object({
+    name         = string
+    plugin_id    = optional(string, "")
+    node_pool    = optional(string, "")
+    capacity_min = optional(string, "")
+    capacity_max = optional(string, "")
+    parameters   = optional(map(string), {})
+    capability = optional(object({
+      access_mode     = optional(string, "single-node-writer")
+      attachment_mode = optional(string, "file-system")
+    }), {})
+  })
+  nullable    = true
+  default     = null
+  description = "Dynamic host volume configuration for storing valkey data"
 }
 
 variable "enable_ephemeral_disk" {


### PR DESCRIPTION
This pull request introduces support for dynamic host volumes to the `nomad-valkey` Terraform module, modernizing data persistence and making it easier to manage storage for Valkey jobs. The documentation is updated to recommend dynamic host volumes, with migration instructions provided for users of legacy static host volumes. The module now requires Nomad provider version 2.4 or higher and exposes new outputs related to dynamic host volumes.

**Dynamic Host Volume Support:**

* Added a new `dynamic_host_volume_config` variable to `variables.tf` to allow configuration of dynamic host volumes for Valkey data storage.
* Created a `nomad_dynamic_host_volume` resource in `main.tf` to provision dynamic host volumes when configured, and updated the Valkey Nomad job to use these volumes.
* Updated the Nomad job template (`valkey.nomad.hcl.tftpl`) to mount dynamic host volumes and attach them to `/data`. [[1]](diffhunk://#diff-730ab178d5295af7f9240282655a0774e8d7999404758ad395eddfed6e097fa9R16-R22) [[2]](diffhunk://#diff-730ab178d5295af7f9240282655a0774e8d7999404758ad395eddfed6e097fa9R66-R71)

**Documentation and Migration:**

* Revised `README.md` to recommend dynamic host volumes, provide configuration examples, and include migration steps from static to dynamic host volumes. [[1]](diffhunk://#diff-097985c7ef6d9efb1b0406d371c3a34079fee2ea4029b3e9c5bec80b28e882c3L28-R59) [[2]](diffhunk://#diff-097985c7ef6d9efb1b0406d371c3a34079fee2ea4029b3e9c5bec80b28e882c3R92-R99)

**Provider and Outputs:**

* Updated the required Nomad provider version to `~> 2.4` in `terraform.tf`.
* Added outputs for the Valkey job name and dynamic host volume details in `outputs.tf`.…ocumentation