### PR TITLE
Modules/nomad client metadata

### DIFF
--- a/modules/nomad/config.tf
+++ b/modules/nomad/config.tf
@@ -80,6 +80,7 @@ locals {
           advertise_addr  = var.advertise_addr
           listen_addr     = var.listen_addr
           enabled         = !var.disable_client
+          client_meta     = var.client_meta
         }
       )
     },

--- a/modules/nomad/templates/client.hcl.tftpl
+++ b/modules/nomad/templates/client.hcl.tftpl
@@ -16,4 +16,11 @@ client = {
     read_only = ${host_volume.read_only}
   }
 %{ endfor ~}
+%{ if length(client_meta) > 0 }
+  meta = {
+%{ for k, v in client_meta ~}
+    ${k} = "${v}"
+%{ endfor ~}
+  }
+%{ endif }
 }

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -126,6 +126,12 @@ variable "host_volume" {
   default     = {}
   description = "Host volume configuration for Nomad"
 }
+ 
+ variable "client_meta" {
+   type        = map(string)
+   default     = {}
+   description = "Custom meta block for Nomad client. Keys and values will be rendered in the client.hcl meta block if provided."
+ }
 
 resource "random_id" "gossip_key" {
   byte_length = 32

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -126,12 +126,12 @@ variable "host_volume" {
   default     = {}
   description = "Host volume configuration for Nomad"
 }
- 
- variable "client_meta" {
-   type        = map(string)
-   default     = {}
-   description = "Custom meta block for Nomad client. Keys and values will be rendered in the client.hcl meta block if provided."
- }
+
+variable "client_meta" {
+  type        = map(string)
+  default     = {}
+  description = "Custom meta block for Nomad client. Keys and values will be rendered in the client.hcl meta block if provided."
+}
 
 resource "random_id" "gossip_key" {
   byte_length = 32


### PR DESCRIPTION
This pull request adds support for configuring custom metadata for Nomad clients. The changes introduce a new variable to allow users to specify key-value pairs that will be rendered in the Nomad client's configuration file under the `meta` block.

**Nomad Client Metadata Support:**

* Added a new variable `client_meta` to `modules/nomad/variables.tf` to allow users to pass custom metadata as a map of key-value pairs.
* Updated `modules/nomad/config.tf` to include `client_meta` in the locals used to render the Nomad client configuration.

**Template Rendering:**

* Modified the `modules/nomad/templates/client.hcl.tftpl` template to conditionally render the `meta` block if `client_meta` is provided, outputting each key-value pair in the configuration file.