### PR TITLE
fix(proxmox): update lifecycle block to ignore changes

### DIFF
--- a/modules/proxmox/proxmox.tf
+++ b/modules/proxmox/proxmox.tf
@@ -105,6 +105,10 @@ resource "proxmox_virtual_environment_vm" "this" {
   }
 
   lifecycle {
+    ignore_changes = [ 
+      ipv4_addresses,
+      network_interface_names
+    ]
     replace_triggered_by = [
       proxmox_virtual_environment_file.provisioning_config
     ]


### PR DESCRIPTION
This pull request introduces a lifecycle configuration update to the `proxmox_virtual_environment_vm` resource in `modules/proxmox/proxmox.tf`. The main change is the addition of `ignore_changes` for specific attributes, which helps prevent unnecessary VM replacements when these attributes change.

Lifecycle management improvements:

* Added `ignore_changes` for `ipv4_addresses` and `network_interface_names` to the `lifecycle` block, ensuring that changes to these attributes do not trigger resource recreation