### PR TITLE
draft: fix(flatcar): create option for resolved mode and fix per-link DNS

### DIFF
--- a/modules/flatcar/config.tf
+++ b/modules/flatcar/config.tf
@@ -44,7 +44,7 @@ locals {
         content = templatefile("${path.module}/templates/default.network.tftpl", {
           ip_address = "${var.ip_address}/${local.subnet_bits}"
           gateway_ip = var.gateway_ip
-        })
+        }) # note that per-link DNS is not enabled, and DNS is configured in global resolved config
         enabled = true
         mode    = "644"
         owner   = "root"
@@ -161,6 +161,16 @@ locals {
       }
     ],
     [for file in flatten(var.substrates.*.files) : file if !endswith(file.path, ".alloy") || var.telemetry.enabled],
+  )
+  links = concat(
+    flatten(var.substrates.*.links),
+    [
+      {
+        path    = "/etc/resolv.conf"
+        target  = "/run/systemd/resolve/stub-resolv.conf"
+        enabled = var.resolved_mode == "stub"
+      }
+    ],
   )
   ssh_authorized_keys = distinct(concat(
     [

--- a/modules/flatcar/ignition.tf
+++ b/modules/flatcar/ignition.tf
@@ -60,6 +60,15 @@ data "ignition_file" "files" {
   }
 }
 
+data "ignition_link" "links" {
+  for_each = {
+    for link in local.links : link.path => link.target if link.enabled == true
+  }
+  path      = each.key
+  target    = each.value
+  overwrite = true
+}
+
 data "ignition_disk" "disks" {
   for_each   = local.disks
   device     = each.key

--- a/modules/flatcar/templates/default.network.tftpl
+++ b/modules/flatcar/templates/default.network.tftpl
@@ -2,7 +2,7 @@
 Name=e*
 
 [Network]
-DNS=127.0.0.53
+DNS=
 %{ if ip_address != "" && gateway_ip != "" ~}
 Address=${ip_address}
 Gateway=${gateway_ip}
@@ -11,4 +11,3 @@ DHCP=yes
 [DHCP]
 UseDNS=false
 %{ endif }
-

--- a/modules/flatcar/variables.tf
+++ b/modules/flatcar/variables.tf
@@ -145,6 +145,12 @@ variable "substrates" {
         group = optional(string, "root")
         })
     ), [])
+    links = optional(
+      list(object({
+        path   = string
+        target = string
+        })
+    ), [])
     install = optional(object({
       systemd_units = list(object({
         name    = string
@@ -188,6 +194,16 @@ variable "ssh_keys_import" {
   validation {
     condition     = length(var.ssh_keys_import) == 0 || alltrue([for item in var.ssh_keys_import : startswith(item, "http")])
     error_message = "SSH key import ID must be a valid URL"
+  }
+}
+
+variable "resolved_mode" {
+  type        = string
+  description = "The operation mode systemd-resolved is working"
+  default     = "uplink"
+  validation {
+    condition     = !contains(flatten(var.substrates.*.packages), "consul") || var.resolved_mode == "stub"
+    error_message = "stub resolver must be used to configure systemd-resolved to use Consul DNS"
   }
 }
 


### PR DESCRIPTION
This PR creates an extra option for using "stub" systemd-resolved mode to allow other programs to resolve DNS via systemd-resolved stub resolver. It also removes per-link DNS settings as we will provide the settings via global resolved config.
