### PR TITLE
Refactor proxmox to reduce necessary resource creation

### DIFF
--- a/modules/proxmox/proxmox.tf
+++ b/modules/proxmox/proxmox.tf
@@ -17,6 +17,10 @@ resource "proxmox_virtual_environment_file" "provisioning_config" {
   }
 }
 
+resource "terraform_data" "digest" {
+  input = md5(var.provisioning_config.payload)
+}
+
 resource "proxmox_virtual_environment_vm" "this" {
   name      = var.name
   node_name = var.node
@@ -107,5 +111,9 @@ resource "proxmox_virtual_environment_vm" "this" {
       interface         = local.cloudinit_drive_interface[var.firmware]
       user_data_file_id = proxmox_virtual_environment_file.provisioning_config[initialization.key].id
     }
+  }
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.digest]
   }
 }

--- a/modules/proxmox/proxmox.tf
+++ b/modules/proxmox/proxmox.tf
@@ -1,4 +1,5 @@
 resource "proxmox_virtual_environment_file" "provisioning_config" {
+  for_each     = local.initialization
   content_type = "snippets"
   datastore_id = "local"
   node_name    = var.node
@@ -100,7 +101,7 @@ resource "proxmox_virtual_environment_vm" "this" {
         }
       }
       interface         = local.cloudinit_drive_interface[var.firmware]
-      user_data_file_id = proxmox_virtual_environment_file.provisioning_config.id
+      user_data_file_id = proxmox_virtual_environment_file.provisioning_config[initialization.key].id
     }
   }
 

--- a/modules/proxmox/proxmox.tf
+++ b/modules/proxmox/proxmox.tf
@@ -1,15 +1,19 @@
+locals {
+  snippet_file_name = format(
+    "%s.%s",
+    sha256(var.provisioning_config.payload),
+    local.provisioning_config_file_format
+  )
+}
+
 resource "proxmox_virtual_environment_file" "provisioning_config" {
   for_each     = local.initialization
   content_type = "snippets"
-  datastore_id = "local"
+  datastore_id = var.snippet_datastore_id
   node_name    = var.node
   source_raw {
-    data = var.provisioning_config.payload
-    file_name = format(
-      "%s.%s",
-      sha256(var.provisioning_config.payload),
-      local.provisioning_config_file_format
-    )
+    data      = var.provisioning_config.payload
+    file_name = local.snippet_file_name
   }
 }
 
@@ -103,11 +107,5 @@ resource "proxmox_virtual_environment_vm" "this" {
       interface         = local.cloudinit_drive_interface[var.firmware]
       user_data_file_id = proxmox_virtual_environment_file.provisioning_config[initialization.key].id
     }
-  }
-
-  lifecycle {
-    replace_triggered_by = [
-      proxmox_virtual_environment_file.provisioning_config
-    ]
   }
 }

--- a/modules/proxmox/proxmox.tf
+++ b/modules/proxmox/proxmox.tf
@@ -17,10 +17,6 @@ resource "proxmox_virtual_environment_file" "provisioning_config" {
   }
 }
 
-resource "terraform_data" "digest" {
-  input = md5(var.provisioning_config.payload)
-}
-
 resource "proxmox_virtual_environment_vm" "this" {
   name      = var.name
   node_name = var.node
@@ -111,9 +107,5 @@ resource "proxmox_virtual_environment_vm" "this" {
       interface         = local.cloudinit_drive_interface[var.firmware]
       user_data_file_id = proxmox_virtual_environment_file.provisioning_config[initialization.key].id
     }
-  }
-
-  lifecycle {
-    replace_triggered_by = [terraform_data.digest]
   }
 }

--- a/modules/proxmox/terraform.tf
+++ b/modules/proxmox/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = "~> 0.81.0"
+      version = "~> 0.83.2"
     }
   }
 }

--- a/modules/proxmox/terraform.tf
+++ b/modules/proxmox/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = "~> 0.83.2"
+      version = ">= 0.81.0, < 1.0.0"
     }
   }
 }

--- a/modules/proxmox/variables.tf
+++ b/modules/proxmox/variables.tf
@@ -17,9 +17,10 @@ variable "tags" {
 
 variable "provisioning_config" {
   type = object({
-    type    = string
-    payload = string
+    type    = optional(string)
+    payload = optional(string)
   })
+  default     = {}
   description = "Either be cloud-init user-data or ignition config"
 }
 
@@ -167,11 +168,10 @@ locals {
     }
   ]
 
-  provisioning_config_file_format = {
+  provisioning_config_file_format = length(keys(var.provisioning_config)) > 0 ? {
     "ignition"   = "ign"
     "cloud-init" = "yaml"
-    "talos"      = "yml"
-  }[var.provisioning_config.type]
+  }[var.provisioning_config.type] : ""
 
   cdrom = var.use_iso ? {
     file_id = var.os_template_id
@@ -182,11 +182,10 @@ locals {
     "uefi" = { "firmware" = "uefi" }
   }[var.firmware]
 
-  initialization = {
+  initialization = length(keys(var.provisioning_config)) > 0 ? {
     "ignition"   = { "${var.provisioning_config.type}" = "" }
     "cloud-init" = { "${var.provisioning_config.type}" = "" }
-    "talos"      = { "${var.provisioning_config.type}" = "" }
-  }[var.provisioning_config.type]
+  }[var.provisioning_config.type] : {}
 
   cloudinit_drive_interface = {
     "bios" = "ide2"

--- a/modules/proxmox/variables.tf
+++ b/modules/proxmox/variables.tf
@@ -17,8 +17,8 @@ variable "tags" {
 
 variable "provisioning_config" {
   type = object({
-    type    = optional(string)
-    payload = optional(string)
+    type    = optional(string, "none")
+    payload = optional(string, "")
   })
   default     = {}
   description = "Either be cloud-init user-data or ignition config"
@@ -168,10 +168,14 @@ locals {
     }
   ]
 
-  provisioning_config_file_format = length(keys(var.provisioning_config)) > 0 ? {
-    "ignition"   = "ign"
-    "cloud-init" = "yaml"
-  }[var.provisioning_config.type] : ""
+  provisioning_config_file_format = lookup(
+    {
+      "ignition"   = "ign"
+      "cloud-init" = "yaml"
+    },
+    var.provisioning_config.type,
+    ""
+  )
 
   cdrom = var.use_iso ? {
     file_id = var.os_template_id
@@ -182,10 +186,14 @@ locals {
     "uefi" = { "firmware" = "uefi" }
   }[var.firmware]
 
-  initialization = length(keys(var.provisioning_config)) > 0 ? {
-    "ignition"   = { "${var.provisioning_config.type}" = "" }
-    "cloud-init" = { "${var.provisioning_config.type}" = "" }
-  }[var.provisioning_config.type] : {}
+  initialization = lookup(
+    {
+      "ignition"   = { "${var.provisioning_config.type}" = "" }
+      "cloud-init" = { "${var.provisioning_config.type}" = "" }
+    },
+    var.provisioning_config.type,
+    {}
+  )
 
   cloudinit_drive_interface = {
     "bios" = "ide2"

--- a/modules/proxmox/variables.tf
+++ b/modules/proxmox/variables.tf
@@ -124,10 +124,10 @@ variable "storage_pool" {
   }
 }
 
-variable "snippet_stored_path" {
+variable "snippet_datastore_id" {
   type        = string
-  default     = "/var/lib/vz/snippets"
-  description = "Filesystem path to store the snippets in Proxmox"
+  default     = "local"
+  description = "Storage used to store the snippets in Proxmox"
 }
 
 variable "qemu_agent_enabled" {


### PR DESCRIPTION
This pull request updates the Proxmox Terraform module to improve flexibility and correctness in provisioning VM configuration files. The changes mainly focus on making the handling of provisioning configs more robust, parameterizing the snippet storage location, and updating provider version constraints.

**Provisioning Config Improvements:**

* The `provisioning_config` variable now uses `optional` types with defaults, allowing for safer handling when no config is provided.
* The file format for provisioning configs is now determined using a `lookup` for better error handling and extensibility.

**Snippet Storage Configuration:**

* Replaced the `snippet_stored_path` variable with `snippet_datastore_id`, allowing users to specify the Proxmox datastore where snippets are stored. The default is set to `"local"`.
* Updated resource definitions to use the new `snippet_datastore_id` variable and a local for the snippet file name, improving configurability.

**VM Resource and Initialization Handling:**

* The VM resource now uses a dynamic map for initialization, supporting multiple config types and referencing the correct provisioning file by key. [[1]](diffhunk://#diff-710f9fb12d0afa6595b5c37e0d482aaa50386646f5df64976075b16bac91c1a2L103-L110) [[2]](diffhunk://#diff-2c634a878224ddb6e54a4cb8b32dae936c232d4cdc93bd66d8597f773c97449eL185-R196)

**Provider Version Constraint:**

* Updated the Proxmox provider version constraint to support all versions from `0.81.0` up to (but not including) `1.0.0`, improving compatibility.