### PR TITLE
Add Hysteria module with configuration and job specifications

### DIFF
--- a/modules/nomad-hysteria/README.md
+++ b/modules/nomad-hysteria/README.md
@@ -1,0 +1,78 @@
+# Terraform module for running Hysteria2 on Nomad
+
+This module deploys a Hysteria2 server on Nomad with built-in self-signed TLS
+certificates and optional obfuscation (salamander). It supports simple password
+authentication and HTTP(S) masquerading.
+
+## Usage
+
+Minimal configuration:
+
+```hcl
+module "hysteria" {
+  source          = "registry.narwhl.workers.dev/stack/hysteria/nomad"
+  datacenter_name = "dc1"
+
+  # Required secrets
+  auth_password = var.HYSTERIA_AUTH_PASSWORD
+  obfs_password = var.HYSTERIA_OBFS_PASSWORD
+}
+```
+
+Example with custom ports and masquerade URL:
+
+```hcl
+module "hysteria" {
+  source          = "registry.narwhl.workers.dev/stack/hysteria/nomad"
+  datacenter_name = "dc1"
+
+  job_name       = "hysteria"
+  listen_port    = 8443      # container listen port
+  bind_port      = 8443      # host port exposed by Nomad
+  masquerade_url = "https://www.bing.com/"
+
+  auth_password = data.external.env.result["HYSTERIA_AUTH_PASSWORD"]
+  obfs_password = data.external.env.result["HYSTERIA_OBFS_PASSWORD"]
+}
+```
+
+## Argument Reference
+
+- `job_name`: `(string: "obfs-proxy")` - Name of the Nomad job.
+
+- `datacenter_name`: `(string: "dc1")` - Datacenter to deploy the job to.
+
+- `namespace`: `(string: "default")` - Namespace to deploy the job to.
+
+- `purge_on_destroy`: `(bool: true)` - Whether to purge the job on destroy.
+
+- `masquerade_url`: `(string: "https://www.bing.com/")` - Upstream URL used for HTTP(S) masquerade.
+
+- `obfs_type`: `(string: "salamander")` - Obfuscation type. Currently salamander is used.
+
+- `obfs_password`: `(string: <required>)` - Password for the obfuscation layer.
+
+- `auth_password`: `(string: <required>)` - Client auth password.
+
+- `listen_port`: `(number: 8443)` - Port Hysteria listens on inside the task.
+
+- `bind_port`: `(number: 8443)` - Fixed host port exposed by Nomad for the service.
+
+- `cert_common_name`: `(string: "hysteria.local")` - Common Name of the generated self-signed certificate.
+
+- `cert_organization`: `(string: "Hysteria")` - Organization of the generated self-signed certificate.
+
+- `cert_ttl`: `(number: 87600)` - Self-signed certificate validity in hours (~10 years).
+
+## Outputs
+
+This module has no outputs.
+
+## Notes
+
+- The container image defaulted in the jobspec is `tobyxdd/hysteria:v2.6.0`.
+- TLS key/cert are generated at apply time using the `tls` provider and
+  mounted into the task at paths defined by the rendered config.
+- Obfuscation uses the `salamander` method with the provided `obfs_password`.
+- The job exposes a single TLS port; ensure your firewall/security groups allow
+  access to `bind_port`.

--- a/modules/nomad-hysteria/main.tf
+++ b/modules/nomad-hysteria/main.tf
@@ -1,0 +1,65 @@
+locals {
+  hysteria_config = {
+    listen : ":${var.listen_port}"
+    tls : {
+      cert : "/hysteria.crt"
+      key : "/hysteria.key"
+    }
+    auth : {
+      type : "password"
+      password : var.auth_password
+    }
+    masquerade : {
+      type : "proxy"
+      proxy : {
+        url : var.masquerade_url
+        rewriteHost : true
+      }
+    }
+    obfs : {
+      type : var.obfs_type
+      salamander : {
+        password : var.obfs_password
+      }
+    }
+  }
+}
+
+resource "tls_private_key" "hysteria" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+resource "tls_self_signed_cert" "hysteria" {
+  private_key_pem = tls_private_key.hysteria.private_key_pem
+
+  subject {
+    common_name  = var.cert_common_name
+    organization = var.cert_organization
+  }
+
+  validity_period_hours = var.cert_ttl
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "nomad_job" "hysteria" {
+  jobspec = templatefile("${path.module}/templates/hysteria.nomad.hcl", {
+    job_name        = var.job_name
+    datacenter      = var.datacenter_name
+    namespace       = var.namespace
+    version         = "v2.6.0"
+    key             = tls_private_key.hysteria.private_key_pem
+    cert            = tls_self_signed_cert.hysteria.cert_pem
+    key_path        = local.hysteria_config.tls.key
+    cert_path       = local.hysteria_config.tls.cert
+    hysteria_config = yamlencode(local.hysteria_config)
+    listen_port     = var.listen_port
+    bind_port       = var.bind_port
+  })
+  purge_on_destroy = var.purge_on_destroy
+}

--- a/modules/nomad-hysteria/main.tf
+++ b/modules/nomad-hysteria/main.tf
@@ -52,7 +52,7 @@ resource "nomad_job" "hysteria" {
     job_name        = var.job_name
     datacenter      = var.datacenter_name
     namespace       = var.namespace
-    version         = "v2.6.0"
+    version         = var.image_version
     key             = tls_private_key.hysteria.private_key_pem
     cert            = tls_self_signed_cert.hysteria.cert_pem
     key_path        = local.hysteria_config.tls.key

--- a/modules/nomad-hysteria/templates/hysteria.nomad.hcl
+++ b/modules/nomad-hysteria/templates/hysteria.nomad.hcl
@@ -1,0 +1,67 @@
+job "${job_name}" {
+  datacenters = ["${datacenter}"]
+  type        = "service"
+
+  group "hysteria" {
+    network {
+      port "tls" {
+        to     = ${listen_port}
+        static = ${bind_port}
+      }
+    }
+
+    task "hysteria" {
+      resources {
+        memory = 256
+      }
+
+      driver = "docker"
+
+      config {
+        image = "tobyxdd/hysteria:${version}"
+        ports = ["tls"]
+        args  = ["server", "-c", "/etc/hysteria.yaml"]
+
+        mount {
+          type   = "bind"
+          source = "local/hysteria.yaml"
+          target = "/etc/hysteria.yaml"
+        }
+
+        mount {
+          type   = "bind"
+          source = "local/hysteria.key"
+          target = "${key_path}"
+        }
+
+        mount {
+          type   = "bind"
+          source = "local/hysteria.crt"
+          target = "${cert_path}"
+        }
+
+      }
+
+      template {
+        destination = "local/hysteria.key"
+        data = <<EOF
+${key}
+        EOF
+      }
+
+      template {
+        destination = "local/hysteria.crt"
+        data = <<EOF
+${cert}
+        EOF
+      }
+
+      template {
+        destination = "local/hysteria.yaml"
+        data = <<-EOF
+${hysteria_config}
+        EOF
+      }
+    }
+  }
+}

--- a/modules/nomad-hysteria/variables.tf
+++ b/modules/nomad-hysteria/variables.tf
@@ -1,6 +1,6 @@
 variable "job_name" {
   type    = string
-  default = "obfs-proxy"
+  default = "hysteria"
 }
 
 variable "datacenter_name" {
@@ -22,6 +22,11 @@ variable "purge_on_destroy" {
   type        = bool
   description = "Whether to purge all jobs on destroy"
   default     = true
+}
+
+variable "image_version" {
+  type    = string
+  default = "v2.6.3"
 }
 
 variable "masquerade_url" {

--- a/modules/nomad-hysteria/variables.tf
+++ b/modules/nomad-hysteria/variables.tf
@@ -1,0 +1,70 @@
+variable "job_name" {
+  type    = string
+  default = "obfs-proxy"
+}
+
+variable "datacenter_name" {
+  type        = string
+  description = "Name of datacenter to deploy jobs to"
+  default     = "dc1"
+  validation {
+    condition     = length(var.datacenter_name) > 0
+    error_message = "Datacenter name must be set"
+  }
+}
+
+variable "namespace" {
+  type    = string
+  default = "default"
+}
+
+variable "purge_on_destroy" {
+  type        = bool
+  description = "Whether to purge all jobs on destroy"
+  default     = true
+}
+
+variable "masquerade_url" {
+  type    = string
+  default = "https://www.bing.com/"
+}
+
+variable "obfs_type" {
+  type    = string
+  default = "salamander"
+}
+
+variable "obfs_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "auth_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "listen_port" {
+  type    = number
+  default = 8443
+}
+
+variable "bind_port" {
+  type    = number
+  default = 8443
+}
+
+variable "cert_common_name" {
+  type    = string
+  default = "hysteria.local"
+}
+
+variable "cert_organization" {
+  type    = string
+  default = "Hysteria"
+}
+
+variable "cert_ttl" {
+  type    = number
+  default = 87600
+}


### PR DESCRIPTION
This pull request introduces a new Terraform module for deploying a Hysteria proxy server on Nomad. The module automates configuration, certificate generation, and job deployment, making it easier to set up a secure, obfuscated proxy service. The main changes are grouped below:

**Nomad Job and Configuration Automation**

* Added a `main.tf` file that defines local Hysteria configuration, generates TLS certificates, and creates a Nomad job resource to deploy the Hysteria server using Docker. The job uses template rendering for config and secrets.
* Added a Nomad job specification template (`hysteria.nomad.hcl`) that configures the job, network ports, Docker task, and mounts for configuration and certificate files. The template uses variables for dynamic configuration.

**Module Variables and Flexibility**

* Introduced a comprehensive set of variables in `variables.tf` to control job name, datacenter, namespace, purge behavior, masquerade URL, obfuscation type and password, authentication password, ports, and certificate details. Sensitive values are marked appropriately.