### PR TITLE
feat(monitoring): add traefk tag

### DIFF
--- a/modules/nomad-grafana-loki-prometheus/main.tf
+++ b/modules/nomad-grafana-loki-prometheus/main.tf
@@ -2,6 +2,48 @@ locals {
   nomad_var_template      = "{{ with nomadVar `nomad/jobs/${var.job_name}` }}{{ .%s }}{{ end }}"
   nomad_upstream_template = "{{ env `NOMAD_UPSTREAM_ADDR_%s` }}"
 
+  // Modified from https://github.com/grafana/docker-otel-lgtm/blob/main/docker/otelcol-config.yaml
+  // With reference to https://opentelemetry.io/docs/collector/configuration/
+  otel_collector_config = yamlencode({
+    receivers = {
+      otlp = {
+        protocols = {
+          grpc = {
+            endpoint = "0.0.0.0:4317"
+          }
+          http = {
+            endpoint = "0.0.0.0:4318"
+          }
+        }
+      }
+    }
+    exporters = {
+      "otlphttp/metrics" = {
+        endpoint = format("http://%s/api/v1/otlp", format(local.nomad_upstream_template, var.service_name_prometheus))
+        tls = {
+          insecure = true
+        }
+      }
+      "otlphttp/logs" = {
+        endpoint = format("http://%s/otlp", format(local.nomad_upstream_template, var.service_name_loki))
+        tls = {
+          insecure = true
+        }
+      }
+    }
+    service = {
+      pipelines = {
+        metrics = {
+          receivers = ["otlp"]
+          exporters = ["otlphttp/metrics"]
+        }
+        logs = {
+          receivers = ["otlp"]
+          exporters = ["otlphttp/logs"]
+        }
+      }
+    }
+  })
   grafana_config = yamlencode({
     apiVersion = 1
     datasources = [
@@ -126,6 +168,8 @@ resource "nomad_job" "grafana_loki_prometheus" {
     job_name                = var.job_name
     datacenter_name         = var.datacenter_name
     namespace               = var.namespace
+    otel_version            = var.otel_version
+    otel_collector_config   = local.otel_collector_config
     grafana_version         = var.grafana_version
     grafana_config          = local.grafana_config
     grafana_admin_password  = format(local.nomad_var_template, "grafana_admin_password")
@@ -136,6 +180,7 @@ resource "nomad_job" "grafana_loki_prometheus" {
     prometheus_version      = var.prometheus_version
     prometheus_config       = local.prometheus_config
     resources               = var.resources
+    service_name_otel       = var.service_name_otel
     service_name_grafana    = var.service_name_grafana
     service_name_loki       = var.service_name_loki
     service_name_prometheus = var.service_name_prometheus

--- a/modules/nomad-grafana-loki-prometheus/templates/jobspec.nomad.hcl.tftpl
+++ b/modules/nomad-grafana-loki-prometheus/templates/jobspec.nomad.hcl.tftpl
@@ -20,12 +20,33 @@ job "${job_name}" {
 
     service {
       name = "${service_name_grafana}"
-      port = "http"
+      tags = [
+        "traefik.http.routers.client.rule=Host(`${grafana_fqdn}`)",
+        "traefik.http.routers.client.entrypoints=${traefik_entrypoints}",
+        "traefik.enable=true",
+        "traefik.consulcatalog.connect=true"
+      ]
+      port = 3000
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "${service_name_loki}"
+              local_bind_port  = 3100
+            }
+            upstreams {
+              destination_name = "${service_name_prometheus}"
+              local_bind_port  = 9090
+            }
+          }
+        }
+      }
       check {
-        type = "http"
-        path = "/api/health"
+        type     = "http"
+        path     = "/api/health"
         interval = "10s"
-        timeout = "2s"
+        timeout  = "2s"
+        expose   = true
       }
     }
 
@@ -61,6 +82,7 @@ ${grafana_config}
   }
   group "loki" {
     network {
+      mode = "bridge"
       port "http" {
         to = 3100
       }
@@ -74,12 +96,16 @@ ${grafana_config}
 
     service {
       name = "${service_name_loki}"
-      port = "http"
+      port = 3100
+      connect {
+        sidecar_service {}
+      }
       check {
-        type = "http"
-        path = "/ready"
+        type     = "http"
+        path     = "/ready"
         interval = "10s"
-        timeout = "2s"
+        timeout  = "2s"
+        expose   = true
       }
     }
 
@@ -145,6 +171,7 @@ ${loki_config}
     }
 
     network {
+      mode = "bridge"
       port "http" {
         to = 9090
       }
@@ -152,12 +179,16 @@ ${loki_config}
 
     service {
       name = "${service_name_prometheus}"
-      port = "http"
+      port = 9090
+      connect {
+        sidecar_service {}
+      }
       check {
-        type = "http"
-        path = "/-/healthy"
+        type     = "http"
+        path     = "/-/healthy"
         interval = "10s"
-        timeout = "2s"
+        timeout  = "2s"
+        expose   = true
       }
     }
 

--- a/modules/nomad-grafana-loki-prometheus/templates/jobspec.nomad.hcl.tftpl
+++ b/modules/nomad-grafana-loki-prometheus/templates/jobspec.nomad.hcl.tftpl
@@ -10,6 +10,63 @@ job "${job_name}" {
     auto_revert = true
   }
 
+  group "otel-collector" {
+    network {
+      mode = "bridge"
+      port "grpc" {
+        to = 4317
+      }
+      port "http" {
+        to = 4318
+      }
+    }
+
+    service {
+      name = "${service_name_otel}-grpc"
+      port = 4317
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    service {
+      name = "${service_name_otel}-http"
+      port = 4318
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "${service_name_loki}"
+              local_bind_port  = 3100
+            }
+            upstreams {
+              destination_name = "${service_name_prometheus}"
+              local_bind_port  = 9090
+            }
+          }
+        }
+      }
+    }
+
+    task "otel-collector" {
+      driver = "docker"
+      config {
+        image = "otel/opentelemetry-collector:${otel_version}"
+        mount {
+          type = "bind"
+          source = "local/collector-config.yaml"
+          target = "/etc/otelcol/config.yaml"
+        }
+      }
+      template {
+        data        = <<EOF
+${otel_collector_config}
+        EOF
+        destination = "local/collector-config.yaml"
+      }
+    }
+  }
+
   group "grafana" {
     network {
       mode = "bridge"
@@ -227,7 +284,8 @@ ${loki_config}
           "--config.file=/etc/prometheus/prometheus.yml",
           "--storage.tsdb.path=/prometheus",
           "--web.enable-lifecycle",
-          "--web.enable-remote-write-receiver"
+          "--web.enable-remote-write-receiver",
+          "--web.enable-otlp-receiver"
         ]
 
         mount {

--- a/modules/nomad-grafana-loki-prometheus/variables.tf
+++ b/modules/nomad-grafana-loki-prometheus/variables.tf
@@ -87,3 +87,14 @@ variable "grafana_admin_password" {
   description = "Grafana admin password. Leave blank to generate a new one with Terraform random resource."
   default     = ""
 }
+
+variable "grafana_fqdn" {
+  type    = string
+  default = "grafana.monitoring.internal"
+}
+
+variable "traefik_entrypoints" {
+  type        = string
+  default     = "http"
+  description = "Entrypoint of Traefik ingress"
+}

--- a/modules/nomad-grafana-loki-prometheus/variables.tf
+++ b/modules/nomad-grafana-loki-prometheus/variables.tf
@@ -23,6 +23,12 @@ variable "purge_on_destroy" {
   description = "Purge the Nomad job on destroy"
 }
 
+variable "otel_version" {
+  type        = string
+  default     = "0.135.0"
+  description = "Version of OTel collector to deploy"
+}
+
 variable "grafana_version" {
   type        = string
   default     = "latest"
@@ -67,6 +73,12 @@ variable "service_name_grafana" {
   type        = string
   default     = "grafana"
   description = "The name of the Grafana service"
+}
+
+variable "service_name_otel" {
+  type        = string
+  default     = "otel-collector"
+  description = "The name of OTel Collector service"
 }
 
 variable "service_name_loki" {


### PR DESCRIPTION
This PR implements the following for the monitoring stack
- Add traefik tag for ingress
- Switch to consul connect for networking
- Add OTel exporter