### PR TITLE
fix(nomad-openfga): use job_name variable for Nomad service names

### DIFF
--- a/modules/nomad-openfga/templates/openfga.nomad.hcl.tftpl
+++ b/modules/nomad-openfga/templates/openfga.nomad.hcl.tftpl
@@ -19,7 +19,7 @@ job "${job_name}" {
     }
 
     service {
-      name     = "openfga-http"
+      name     = "${job_name}-http"
       provider = "nomad"
       port     = "http"
       tags = [
@@ -37,14 +37,14 @@ job "${job_name}" {
     }
 
     service {
-      name     = "openfga-grpc"
+      name     = "${job_name}-grpc"
       provider = "nomad"
       port     = "grpc"
     }
 
 %{ if playground_enabled ~}
     service {
-      name     = "openfga-playground"
+      name     = "${job_name}-playground"
       provider = "nomad"
       port     = "playground"
     }


### PR DESCRIPTION
Service names were hardcoded as openfga-http, openfga-grpc, and openfga-playground, ignoring the configurable job_name variable. This caused service discovery issues when deploying with a custom job name.