### PR TITLE
feat(nomad-ingress): add HTTP to HTTPS redirect option

### DIFF
--- a/modules/nomad-ingress/main.tf
+++ b/modules/nomad-ingress/main.tf
@@ -91,7 +91,8 @@ resource "nomad_job" "ingress-controller" {
         service_name  = var.consul_provider_config.service_name == "" ? var.controller_job_name : var.consul_provider_config.service_name
         sidecars      = var.consul_provider_config.connect_aware ? [] : [{}]
       }]
-      static_routes = var.static_routes
+      static_routes                 = var.static_routes
+      enable_http_to_https_redirect = var.enable_http_to_https_redirect
     }
   )
 }

--- a/modules/nomad-ingress/templates/traefik.nomad.hcl.tftpl
+++ b/modules/nomad-ingress/templates/traefik.nomad.hcl.tftpl
@@ -56,6 +56,11 @@ job "${job_name}" {
 [entryPoints]
   [entryPoints.http]
     address = ":{{ env `NOMAD_PORT_http` }}"
+%{ if enable_http_to_https_redirect ~}
+    [entryPoints.http.http.redirections.entryPoint]
+      to = "https"
+      scheme = "https"
+%{ endif ~}
   [entryPoints.https]
     address = ":{{ env `NOMAD_PORT_https` }}"
 

--- a/modules/nomad-ingress/variables.tf
+++ b/modules/nomad-ingress/variables.tf
@@ -106,3 +106,9 @@ variable "use_https" {
   description = "Whether to use https for ingress"
   default     = false
 }
+
+variable "enable_http_to_https_redirect" {
+  type        = bool
+  description = "Whether to redirect HTTP traffic to HTTPS"
+  default     = false
+}


### PR DESCRIPTION
Add `enable_http_to_https_redirect` variable that configures Traefik to automatically redirect HTTP traffic to HTTPS using a permanent (301) redirect at the entry point level.