### PR TITLE
feat(nomad-minio): add constraint support for dynamic host volumes

### DIFF
--- a/modules/nomad-minio/main.tf
+++ b/modules/nomad-minio/main.tf
@@ -21,6 +21,15 @@ resource "nomad_dynamic_host_volume" "minio_data" {
   capacity_max = var.dynamic_host_volume_config.capacity_max
   parameters   = var.dynamic_host_volume_config.parameters
 
+  dynamic "constraint" {
+    for_each = var.dynamic_host_volume_config.constraints
+    content {
+      attribute = constraint.value.attribute
+      operator  = constraint.value.operator
+      value     = constraint.value.value
+    }
+  }
+
   dynamic "capability" {
     for_each = var.dynamic_host_volume_config.capability != null ? [var.dynamic_host_volume_config.capability] : []
     content {

--- a/modules/nomad-minio/variables.tf
+++ b/modules/nomad-minio/variables.tf
@@ -70,6 +70,11 @@ variable "dynamic_host_volume_config" {
     capacity_min = optional(string, "")
     capacity_max = optional(string, "")
     parameters   = optional(map(string), {})
+    constraints = optional(list(object({
+      attribute = string
+      operator  = optional(string)
+      value     = optional(string)
+    })), [])
     capability = optional(object({
       access_mode     = optional(string, "single-node-writer")
       attachment_mode = optional(string, "file-system")


### PR DESCRIPTION
## Summary

- Add optional `constraints` field to `dynamic_host_volume_config` in the `nomad-minio` module, allowing callers to specify node constraints for volume placement
- Uses `dynamic "constraint"` block on the `nomad_dynamic_host_volume` resource to render zero or more constraints
- Non-breaking: defaults to `[]`, so existing callers require no changes

## Test plan

- [x] Run `terraform fmt` and `terraform validate` on the module
- [ ] Verify existing consumers (e.g. `infrastructure/services`) plan cleanly without passing `constraints`
- [ ] Test with a constraint (e.g. `attribute = "${attr.unique.hostname}"`, `value = "nomad-7624c5"`) and confirm the volume is placed on the expected node
