### PR TITLE
feat(nomad-ory): add optional Traefik routing for admin endpoints

### DIFF
--- a/modules/nomad-ory-hydra-kratos/main.tf
+++ b/modules/nomad-ory-hydra-kratos/main.tf
@@ -62,6 +62,8 @@ resource "nomad_job" "hydra_kratos" {
       kratos_public_fqdn    = local.kratos_public_fqdn
       traefik_entrypoint    = var.traefik_entrypoint
       traefik_cert_resolver = var.traefik_cert_resolver
+      hydra_admin_fqdn      = var.hydra_admin_fqdn
+      kratos_admin_fqdn     = var.kratos_admin_fqdn
     }
   )
 }

--- a/modules/nomad-ory-hydra-kratos/templates/jobspec.nomad.hcl.tftpl
+++ b/modules/nomad-ory-hydra-kratos/templates/jobspec.nomad.hcl.tftpl
@@ -37,6 +37,13 @@ job "${job_name}" {
       name     = "hydra-admin"
       provider = "nomad"
       port     = "hydra-admin"
+%{ if hydra_admin_fqdn != "" ~}
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.hydra-admin.rule=Host(`${hydra_admin_fqdn}`)",
+        "traefik.http.routers.hydra-admin.entrypoints=${traefik_entrypoint.admin}",
+      ]
+%{ endif ~}
       check {
         type     = "http"
         port     = "hydra-admin"
@@ -165,6 +172,13 @@ ${hydra_config}
       name     = "kratos-admin"
       provider = "nomad"
       port     = "kratos-admin"
+%{ if kratos_admin_fqdn != "" ~}
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.kratos-admin.rule=Host(`${kratos_admin_fqdn}`)",
+        "traefik.http.routers.kratos-admin.entrypoints=${traefik_entrypoint.admin}",
+      ]
+%{ endif ~}
       check {
         type     = "http"
         port     = "kratos-admin"

--- a/modules/nomad-ory-hydra-kratos/variables.tf
+++ b/modules/nomad-ory-hydra-kratos/variables.tf
@@ -274,18 +274,32 @@ variable "traefik_entrypoint" {
   type = object({
     http  = optional(string, "http")
     https = optional(string, "https")
+    admin = optional(string, "")
   })
   default = {
     http  = "http"
     https = "https"
+    admin = ""
   }
-  description = "Traefik entrypoint to use"
+  description = "Traefik entrypoints to use. The admin entrypoint is used for admin API routing when hydra_admin_fqdn or kratos_admin_fqdn is set."
 }
 
 variable "traefik_cert_resolver" {
   type        = string
   default     = ""
   description = "Name of the Traefik certificate resolver for automatic SSL certificates (e.g., 'letsencrypt'). Leave empty to disable automatic certificate management."
+}
+
+variable "hydra_admin_fqdn" {
+  type        = string
+  default     = ""
+  description = "FQDN for Traefik routing to the hydra admin endpoint. Empty to disable."
+}
+
+variable "kratos_admin_fqdn" {
+  type        = string
+  default     = ""
+  description = "FQDN for Traefik routing to the kratos admin endpoint. Empty to disable."
 }
 
 locals {


### PR DESCRIPTION
Add hydra_admin_fqdn and kratos_admin_fqdn variables with a new traefik_entrypoint.admin field, following the existing convention used by public endpoints (hydra_public_fqdn, traefik_entrypoint.http/https).

When an admin FQDN is set, Traefik tags are added to the corresponding service for Host-based routing on the admin entrypoint. Defaults to empty (no tags), preserving backward compatibility.